### PR TITLE
SUBMISSION-20: Fix failure to progress from Submission Agreement step.

### DIFF
--- a/submit_ce/ui/controllers/new/policy.py
+++ b/submit_ce/ui/controllers/new/policy.py
@@ -33,7 +33,7 @@ def policy(method: str, params: MultiDict, session: Session,
     submission, submission_events = get_submission(submission_id)
 
     if method == 'GET' and submission.submitter_accepts_policy:
-        params['policy'] = 'true'
+        params['policy'] = 'y'
 
     current_policy_id=3  # TODO !!! add to api and use that
     form = PolicyForm(params, current_policy_id)

--- a/submit_ce/ui/templates/submit/policy.html
+++ b/submit_ce/ui/templates/submit/policy.html
@@ -5,32 +5,42 @@
 
 {% block within_content %}
 <form id="form" method="POST" action="{{ url_for('ui.policy', submission_id=submission_id) }}">
-  <div class="content-container">
-    <h2>Terms and Conditions - Scroll to read before proceeding</h2>
-    <div class="policy-scroll">
-      <p>Updated Submission Agreement</p>
-    </div>
-  </div>
-
-  {# The policy id is the id of the policy statement the user has been show. If the above policy text changes the policy
-     id should change and a new entry added to the db. #}
-  {{ form.policy_id }}
-
-  <div class="action-container">
-      {{ form.csrf_token }}
-      {% if form.policy.errors %}<div class="notification is-danger">{% endif %}
-      <div class="field">
-        <div class="control">
-          <div class="checkbox">
-            {{ form.policy }}
-            {{ form.policy.label }}
-          </div>
-          {% for error in form.policy.errors %}
-            <p class="help is-danger field-error">{{ error }}</p>
-          {% endfor %}
+    <div class="content-container">
+        <h2>Terms and Conditions - Scroll to read before proceeding</h2>
+        <div class="policy-scroll">
+            <p>Updated Submission Agreement</p>
         </div>
-      </div>
-      {% if form.policy.errors %}</div>{% endif %}
-  </div>
+    </div>
+
+    {# The policy id is the id of the policy statement the user has been show. If the above policy text changes the
+    policy
+    id should change and a new entry added to the db. #}
+    {{ form.policy_id }}
+
+    <div class="action-container">
+        {{ form.csrf_token }}
+        {% if form.policy.errors %}
+        <div class="notification is-danger">{% endif %}
+            <div class="field">
+                <div class="control">
+                    <div class="checkbox">
+                        <input
+                                type="checkbox"
+                                id="{{ form.policy.id }}"
+                                name="{{ form.policy.name }}"
+                                value="y"
+                                {% if form.policy.data %}checked{% endif %}
+                        >
+                        {{ form.policy.label }}
+                    </div>
+                    {% for error in form.policy.errors %}
+                    <p class="help is-danger field-error">{{ error }}</p>
+                    {% endfor %}
+                </div>
+            </div>
+            {% if form.policy.errors %}
+        </div>
+        {% endif %}
+    </div>
 </form>
 {% endblock within_content %}


### PR DESCRIPTION
This PR fixes the problem "User is NOT able to progress beyond Policy step using Continue and Save".

This was a pesky little issue that took a bit to figure out. A couple of incomplete/incompatible pieces made this appear as an issue with caching, but turns out to be an issue with not sending a value back from the form and then looking for the wrong value at the controller when repopulating the form. All fixed.

You are now able to confirm submission agreement, move around to other steps, and return to have the confirm checkbox selected.

@SBBCornell : 
**A UI question: Since the submitter is not able to revoke the confirmation, and doing so generates an error, why do we even allow the submitter to unselect the checkbox once they have confirmed the submission agreement?**