### PR TITLE
SUBMISSION-83: Save Submission Agreement identifier to DB

### DIFF
--- a/submit_ce/domain/event/__init__.py
+++ b/submit_ce/domain/event/__init__.py
@@ -242,7 +242,8 @@ class ConfirmPolicy(Event):
 
     NAME = "confirm policy acceptance"
     NAMED = "policy acceptance confirmed"
-
+    agreement_id: int
+    
     def validate(self, submission: Submission) -> None:
         """Cannot apply to a finalized submission."""
         validators.submission_is_not_finalized(self, submission)
@@ -250,6 +251,7 @@ class ConfirmPolicy(Event):
     def project(self, submission: Submission) -> Submission:
         """Set the policy flag on the submission."""
         submission.submitter_accepts_policy = True
+        submission.agreement_id = self.agreement_id
         return submission
 
 

--- a/submit_ce/domain/event/tests/test_init_events_pytest.py
+++ b/submit_ce/domain/event/tests/test_init_events_pytest.py
@@ -112,10 +112,25 @@ def test_confirm_authorship(mock_user, base_submission):
     assert sub.submitter_is_author is True
 
 def test_confirm_policy(mock_user, base_submission):
-    e = event.ConfirmPolicy(creator=mock_user, created=datetime.now(UTC))
+    e = event.ConfirmPolicy(
+        creator=mock_user,
+        created=datetime.now(UTC),
+        agreement_id=3  # NEW REQUIRED FIELD
+    )
     e.validate(base_submission)
     sub = e.project(base_submission)
     assert sub.submitter_accepts_policy is True
+
+def test_confirm_policy_sets_agreement_id(mock_user, base_submission):
+    e = event.ConfirmPolicy(
+        creator=mock_user,
+        created=datetime.now(UTC),
+        agreement_id=3
+    )
+    e.validate(base_submission)
+    sub = e.project(base_submission)
+
+    assert sub.agreement_id == 3
 
 def test_set_primary_classification(mock_user, base_submission):
     category = 'astro-ph.GA'

--- a/submit_ce/domain/submission.py
+++ b/submit_ce/domain/submission.py
@@ -323,6 +323,9 @@ class Submission:
     is_source_processed: bool = field(default=False)
     submitter_confirmed_preview: bool = field(default=False)
     license: Optional[License] = field(default=None)
+
+    agreement_id: Optional[str] = None
+
     status: str = field(default=WORKING)
     """Disposition within the submission pipeline."""
 

--- a/submit_ce/implementations/legacy_implementation/models.py
+++ b/submit_ce/implementations/legacy_implementation/models.py
@@ -88,6 +88,7 @@ class Submission(Base):    # type: ignore
      userinfo: 0
      is_author: 0
      agree_policy: 0
+     agreement_id: Optional[int] = None
      viewed: 0
      submitter_id: '10'
      submitter_name: ''
@@ -133,6 +134,7 @@ class Submission(Base):    # type: ignore
     userinfo = Column(Integer, server_default=text("'0'"))
     is_author = Column(Integer, nullable=False, server_default=text("'0'"))
     agree_policy = Column(Integer, server_default=text("'0'"))
+    agreement_id = Column(Integer, nullable=True)
     viewed = Column(Integer, server_default=text("'0'"))
     stage = Column(Integer, server_default=text("'0'"))
     submitter_id = Column(
@@ -253,6 +255,7 @@ class Submission(Base):    # type: ignore
         self.submitter_email = submission.creator.email
         self.is_author = 1 if submission.submitter_is_author else 0
         self.agree_policy = 1 if submission.submitter_accepts_policy else 0
+        self.agreement_id = submission.agreement_id
         self.userinfo = 1 if submission.submitter_contact_verified else 0
         self.viewed = 1 if submission.submitter_confirmed_preview else 0
         self.updated = submission.updated

--- a/submit_ce/ui/conftest.py
+++ b/submit_ce/ui/conftest.py
@@ -220,7 +220,7 @@ def sub_policy(app, authorized_user, sub_authorship):
         user = authorized_user
         ua = InternalClient(name=f"test_client_{__file__}")
         submission, _ = current_app.api.save(
-            ConfirmPolicy(creator=user, client=ua),
+            ConfirmPolicy(creator=user, client=ua, agreement_id=1),
             submission_id=sub_authorship.submission_id)
         return submission
 
@@ -351,7 +351,7 @@ def submitted_submission(app, authorized_user):
             ConfirmContactInformation(creator=user, client=ua),
             ConfirmAuthorship(creator=user, client=ua, submitter_is_author=True),
             SetLicense(creator=user, client=ua, license_uri=cc0, license_name="CC0 1.0"),
-            ConfirmPolicy(creator=user, client=ua),
+            ConfirmPolicy(creator=user, client=ua, agreement_id=1),
             SetPrimaryClassification(creator=user, client=ua, category="astro-ph.GA"),
             SetUploadPackage(creator=user, client=ua,
                 checksum="a9s9k342900skks03330029k",
@@ -396,7 +396,7 @@ def published_submission(app, authorized_user):
             SetLicense(
                 creator=user, client=ua, license_uri=cc0, license_name="CC0 1.0"
             ),
-            ConfirmPolicy(creator=user, client=ua),
+            ConfirmPolicy(creator=user, client=ua, agreement_id=1),
             SetPrimaryClassification(creator=user, client=ua, category="astro-ph.GA"),
             SetUploadPackage(
                 creator=user,

--- a/submit_ce/ui/controllers/new/policy.py
+++ b/submit_ce/ui/controllers/new/policy.py
@@ -71,8 +71,10 @@ def policy(method: str, params: MultiDict, session: Session,
         return stay_on_this_stage((response_data, status.BAD_REQUEST, {}))
 
     if accept_policy and not submission.submitter_accepts_policy:
-        command = ConfirmPolicy(creator=submitter, client=client)
+        command = ConfirmPolicy(creator=submitter, client=client,
+                                agreement_id=form.policy_id.data)
         if validate_command(form, command, submission, 'policy'):
+            submission.agreement_id = form.policy_id.data
             submission, _ = current_app.api.save(command, submission_id=submission_id)
             response_data['submission'] = submission
             return ready_for_next((response_data, status.OK, {}))

--- a/submit_ce/ui/controllers/new/tests/test_policy_post.py
+++ b/submit_ce/ui/controllers/new/tests/test_policy_post.py
@@ -1,0 +1,230 @@
+# submit_ce/ui/controllers/tests/test_policy_post.py
+
+from flask import current_app
+from sqlalchemy import text
+from arxiv.db import Session
+from submit_ce.ui.tests.csrf_util import parse_csrf_token
+
+from flask import current_app
+from sqlalchemy import text
+from arxiv.db import Session
+from submit_ce.ui.tests.csrf_util import parse_csrf_token
+
+
+def test_policy_post_sets_agreement_id(app, authorized_client, sub_authorship):
+    """
+    Ensure a valid POST to /<sid>/policy:
+    - Accepts the current policy ID (3)
+    - Creates ConfirmPolicy with agreement_id=3
+    - Persists agree_policy=1 and agreement_id=3 into classic DB
+    - Returns HTTP 200 (ready_for_next)
+    """
+
+    sid = sub_authorship.submission_id
+    policy_id = 3
+
+    with app.app_context():
+        # STEP 1: GET form to extract CSRF token
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        assert get_resp.status_code == 200
+
+        csrf = parse_csrf_token(get_resp)
+
+        # STEP 2: POST valid policy acceptance
+        post_resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={
+                "csrf_token": csrf,
+                "policy_id": policy_id,
+                "policy": "y"
+            }
+        )
+
+        # Controller returns 200 OK on success (not a redirect)
+        assert post_resp.status_code == 200
+
+        # STEP 3: Check DB
+        row = Session.execute(
+            text("""
+                SELECT agree_policy, agreement_id
+                FROM arXiv_submissions
+                WHERE submission_id = :sid
+            """),
+            {"sid": sid}
+        ).fetchone()
+
+        assert row is not None, "Submission row should exist"
+        assert row.agree_policy == 1
+        assert row.agreement_id == policy_id
+
+
+def test_policy_round_trip_after_accept(app, authorized_client, sub_authorship):
+    """
+    After accepting the policy:
+    - A subsequent GET should show policy pre-checked
+    - Database should contain updated agreement_id and agree_policy
+    """
+    sid = sub_authorship.submission_id
+    policy_id = 3
+
+    with app.app_context():
+        # 1. GET to retrieve CSRF token
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        assert get_resp.status_code == 200
+
+        csrf = parse_csrf_token(get_resp)
+
+        # 2. POST to accept policy
+        post_resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={
+                "csrf_token": csrf,
+                "policy_id": policy_id,
+                "policy": "y",
+            }
+        )
+        assert post_resp.status_code == 200
+
+        # 3. GET again; policy must now show as accepted
+        get2 = authorized_client.get(f"/{sid}/policy")
+        assert get2.status_code == 200
+        assert b'checked' in get2.data or b'value="y"' in get2.data
+
+        # 4. Confirm DB row updated
+        row = Session.execute(
+            text("""
+                SELECT agree_policy, agreement_id
+                FROM arXiv_submissions
+                WHERE submission_id = :sid
+            """),
+            {"sid": sid}
+        ).fetchone()
+
+        assert row.agree_policy == 1
+        assert row.agreement_id == policy_id
+
+
+def test_policy_post_wrong_policy_id(app, authorized_client, sub_authorship):
+    """
+    POST fails (400) if policy_id does not match current_policy_id=3.
+    """
+    sid = sub_authorship.submission_id
+
+    with app.app_context():
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        assert get_resp.status_code == 200
+        csrf = parse_csrf_token(get_resp)
+
+        resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={"csrf_token": csrf, "policy_id": 99, "policy": "y"}
+        )
+        assert resp.status_code == 400
+
+
+def test_policy_post_missing_policy_checkbox(app, authorized_client, sub_authorship):
+    """
+    POST fails (400) if 'policy' checkbox ("y") is missing.
+    """
+    sid = sub_authorship.submission_id
+
+    with app.app_context():
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        csrf = parse_csrf_token(get_resp)
+
+        resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={"csrf_token": csrf, "policy_id": 3}  # missing "policy"
+        )
+        assert resp.status_code == 400
+
+
+def test_policy_post_missing_policy_id(app, authorized_client, sub_authorship):
+    """
+    POST fails (400) if 'policy_id' is missing.
+    """
+    sid = sub_authorship.submission_id
+
+    with app.app_context():
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        csrf = parse_csrf_token(get_resp)
+
+        resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={"csrf_token": csrf, "policy": "y"}  # missing policy_id
+        )
+        assert resp.status_code == 400
+
+
+def test_policy_post_unexpected_extra_field(app, authorized_client, sub_authorship):
+    """
+    POST fails (400) if unexpected form fields are included.
+    """
+    sid = sub_authorship.submission_id
+
+    with app.app_context():
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        csrf = parse_csrf_token(get_resp)
+
+        resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={
+                "csrf_token": csrf,
+                "policy_id": 3,
+                "policy": "y",
+                "evil": "not-allowed"
+            }
+        )
+        assert resp.status_code == 400
+
+
+def test_policy_cannot_unaccept_after_accepting(app, authorized_client, sub_authorship):
+    """
+    Once the policy is accepted, the user cannot unaccept it.
+    POST with policy="n" must return 400.
+    """
+    sid = sub_authorship.submission_id
+
+    with app.app_context():
+        # Accept policy first
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        csrf = parse_csrf_token(get_resp)
+
+        authorized_client.post(
+            f"/{sid}/policy",
+            data={"csrf_token": csrf, "policy_id": 3, "policy": "y"}
+        )
+
+        # Try to unaccept
+        get_resp2 = authorized_client.get(f"/{sid}/policy")
+        csrf2 = parse_csrf_token(get_resp2)
+
+        resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={"csrf_token": csrf2, "policy_id": 3, "policy": "n"}
+        )
+        assert resp.status_code == 400
+
+
+def test_policy_accept_advances_workflow(app, authorized_client, sub_authorship):
+    """
+    After accepting policy:
+    - ready_for_next() is invoked
+    - submission reflects submitter_accepts_policy=True
+    """
+    sid = sub_authorship.submission_id
+
+    with app.app_context():
+        get_resp = authorized_client.get(f"/{sid}/policy")
+        csrf = parse_csrf_token(get_resp)
+
+        resp = authorized_client.post(
+            f"/{sid}/policy",
+            data={"csrf_token": csrf, "policy_id": 3, "policy": "y"},
+            follow_redirects=True
+        )
+
+        assert resp.status_code == 200
+        # Workflow advanced: submission now has submitter_accepts_policy=True
+        submission = current_app.api.get(str(sid))
+        assert submission.submitter_accepts_policy is True

--- a/submit_ce/ui/tests/test_policy_persistence.py
+++ b/submit_ce/ui/tests/test_policy_persistence.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from pytz import UTC
+from flask import current_app
+from arxiv.db import Session
+from sqlalchemy import text
+
+from submit_ce.domain.event import ConfirmPolicy, CreateSubmission
+from submit_ce.domain.agent import InternalClient
+
+def test_confirm_policy_persists_agreement_id(app, authorized_user):
+    """Ensure ConfirmPolicy writes agree_policy=1 and agreement_id=X into classic DB."""
+    with app.app_context():
+        user = authorized_user
+        client = InternalClient(name="test_policy_persist")
+
+        # 1. Create a new submission
+        submission, _ = current_app.api.save(
+            CreateSubmission(creator=user, client=client)
+        )
+        sid = submission.submission_id
+
+        # 2. Apply ConfirmPolicy with agreement_id
+        submission, _ = current_app.api.save(
+            ConfirmPolicy(
+                creator=user,
+                client=client,
+                agreement_id=42
+            ),
+            submission_id=sid
+        )
+
+        # 3. Query classic DB directly
+        row = Session.execute(
+            text("""
+                        SELECT agree_policy, agreement_id
+                        FROM arXiv_submissions
+                        WHERE submission_id = :sid
+                    """),
+            {"sid": sid}
+        ).fetchone()
+
+        assert row is not None
+        assert row.agree_policy == 1
+        assert row.agreement_id == 42
+


### PR DESCRIPTION
This PR fixes a minor omission in the backend code for saving the submission agreement identifier. Support for saving agreement_id to DB was not implemented in Submit 2.0. This PR updates policy.py, domain, and model so agreement_id is saved to DB.

This PR also adds more comprehensive  tests of the policy controller. 

sqlite> select submission_id, agree_policy,agreement_id from arXiv_submissions;
1|1|3
2|1|3

