### PR TITLE
Fix serialize-decisions-via-event approach

### DIFF
--- a/submit_ce/domain/event/process.py
+++ b/submit_ce/domain/event/process.py
@@ -269,3 +269,51 @@ class SetDecisions(EventWithSideEffect):
     def project(self, submission: Submission) -> Submission:
         submission.uncompressed_size -= self.bytes_removed
         return submission
+
+
+class SetDirectivesAndCleanup(EventWithSideEffect):
+    """Prepare the submission for a (re)run of preflight.
+
+    Performed atomically under the submission row lock taken by
+    `SubmitApi.save()`:
+
+    1. If a 00README.json ("zzrm") was found and converted to
+       user_decisions before this event was dispatched, persist
+       those user_decisions and delete the source 00README.json.
+    2. Delete the stale directives.json so the upcoming preflight
+       produces a fresh set.
+
+    This event is invoked from review.py's `_load_or_create_preflight`
+    immediately before triggering `StartPreflight`, so the cleanup
+    cannot interleave with a concurrent upload on the same
+    submission.
+    """
+
+    NAME = "set directives and cleanup"
+    NAMED = "directives reset and cleaned up"
+
+    # If provided, the value is written as user_decisions.json and
+    # the source 00README.json is deleted. If None, user_decisions
+    # and 00README.json are left untouched.
+    user_decisions_from_zzrm: Optional[dict] = None
+
+    def validate(self, submission: Submission) -> None:
+        # No input invariants: the event is always safe to dispatch
+        # from `_load_or_create_preflight`; an absent zzrm just means
+        # "skip the user_decisions seed step."
+        pass
+
+    def execute(self, api: SubmitApi, submission: Submission) -> None:
+        file_store = api.get_file_store()
+        if self.user_decisions_from_zzrm is not None:
+            file_store.store_user_decisions(
+                submission.submission_id, self.user_decisions_from_zzrm
+            )
+            file_store.delete_source_file(
+                submission.submission_id, '00README.json'
+            )
+        # user_decisions + preflight + compile logs -> directives.json
+        file_store.delete_directives(submission.submission_id)
+
+    def project(self, submission: Submission) -> Submission:
+        return submission

--- a/submit_ce/implementations/legacy_implementation/__init__.py
+++ b/submit_ce/implementations/legacy_implementation/__init__.py
@@ -172,6 +172,12 @@ class LegacySubmitImplementation(SubmitApi):
                 if event.executed:
                     raise RuntimeError("Must not save and execute an already executed event. "
                                        "{event.event_id} {event.NAME} executed {event.executed}")
+                # pre_execute_validation runs inside the locked
+                # transaction so it can inspect on-disk / FileStore
+                # state without racing against another writer. Raising
+                # InvalidEvent here rolls the transaction back; the
+                # caller's `except InvalidEvent` decides UX.
+                event.pre_execute_validation(self, before)
                 logger.debug('Execute event %s: %s', event.event_id, event.NAME)
                 event.execute(self, before)
                 if not event.executed:

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -6,7 +6,12 @@ from typing import Tuple, Dict, Any, Optional, List
 from flask import current_app
 from arxiv.auth.domain import Session
 from arxiv.base import alerts
-from submit_ce.domain.event.process import SetDecisions, StartPreflight, StartDirectives  # noqa: F401 (StartDirectives used below)
+from submit_ce.domain.event.process import (
+    SetDecisions,
+    SetDirectivesAndCleanup,
+    StartPreflight,
+    StartDirectives,  # noqa: F401 (StartDirectives used below)
+)
 from submit_ce.domain.event import SetSourceFormat
 from ...auth import user_and_client_from_session
 from arxiv.files import FileDoesNotExist
@@ -146,7 +151,9 @@ def review_files(method: str, params: MultiDict, session: Session,
         return return_to_parent_stage((rdata, status.OK, {}))
 
     if method == 'GET':
-        preflight_data, user_decisions_data = _load_or_create_preflight(submission_id, params, session, token, workspace)
+        preflight_data, user_decisions_data = _load_or_create_preflight(
+            submission_id, params, session, token, workspace, submitter, client
+        )
 
         if preflight_data is None:
             alerts.flash_warning(
@@ -216,7 +223,7 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
     try:
         cmd = SetDecisions(creator=submitter, client=client,
                            decisions=new_decisions, files_to_delete=files_to_delete)
-        current_app.api.save(cmd)
+        current_app.api.save(cmd, submission_id=submission_id)
         return True
     except InvalidEvent:
         # TODO Somehow inform the user
@@ -245,22 +252,42 @@ def _populate_form(form: ReviewForm, preflight_data: Optional[dict], user_decisi
     )
 
 
-def _load_or_create_preflight(submission_id: str, params: MultiDict, session: Session, token: str, workspace) -> tuple[Optional[dict], Optional[dict]]:
+def _load_or_create_preflight(
+    submission_id: str,
+    params: MultiDict,
+    session: Session,
+    token: str,
+    workspace,
+    submitter,
+    client,
+) -> tuple[Optional[dict], Optional[dict]]:
     """Returns preflight and user_decisions"""
     preflight_data = _get_preflight_data(submission_id)
     zzrm_data = None
     if preflight_data is None:
-        file_store = current_app.api.get_file_store()
         # if there is no preflight, then there wouldn't be a user decisions file.
         #   check if there is a zzrm, and use that as initial user decisions.
-        zzrm_data = _get_zzrm_data(workspace, submission_id)
-        if zzrm_data is not None:
-            zzrm_data = dm.convert_zzrm_to_user_decisions(zzrm_data)
-            file_store.store_user_decisions(submission_id, zzrm_data)
-            file_store.delete_source_file(submission_id, '00README.json')
+        raw_zzrm = _get_zzrm_data(workspace, submission_id)
+        zzrm_data = (
+            dm.convert_zzrm_to_user_decisions(raw_zzrm)
+            if raw_zzrm is not None else None
+        )
 
-        # user_decisions + preflight + compile logs -> directives.json
-        file_store.delete_directives(submission_id)
+        # Cleanup (seed user_decisions, drop 00README, clear stale
+        # directives.json) runs through api.save so the mutations
+        # happen inside the per-submission row lock — no concurrent
+        # upload can interleave between cleanup and start_preflight.
+        try:
+            current_app.api.save(
+                SetDirectivesAndCleanup(
+                    creator=submitter,
+                    client=client,
+                    user_decisions_from_zzrm=zzrm_data,
+                ),
+                submission_id=submission_id,
+            )
+        except InvalidEvent:
+            pass  # nothing actionable in cleanup is fine
 
         start_preflight(params, session, submission_id, token)
         preflight_data = _get_preflight_data(submission_id)


### PR DESCRIPTION
- review.py `_update_preflight`: pass `submission_id=submission_id` to `api.save(cmd)`. Without it, `LegacySubmitImplementation.save` hits the `submission_id is None and not isinstance(events[0], CreateSubmission)` branch and raises `NoSuchSubmission` instead of locking and executing the event.

- `LegacySubmitImplementation._save`: call `event.pre_execute_validation(self, before)` before `event.execute(self, before)`, inside the locked transaction. The hook was defined on `EventWithSideEffect` but never invoked, so `SetDecisions.pre_execute_validation` was dead code. Raising `InvalidEvent` from the hook now rolls back the transaction and is caught by the controller's `except InvalidEvent`.

- Add `SetDirectivesAndCleanup` event for the second mutation site in `_load_or_create_preflight` (seed user_decisions from zzrm, drop 00README.json, clear stale directives.json). Threads submitter/client from `review_files`. Dispatched via `api.save(cmd, submission_id=submission_id)` so the cleanup happens under the per-submission row lock, before the subsequent `start_preflight(...)` call (which acquires its own lock via `save()`). Includes a no-op `validate()` because `event.apply()` calls it.