### PR TITLE
Withdraw

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,3 +249,18 @@ exclude = [
     ".git",
 ]
 
+[tool.pytest.ini_options]
+# Suppress deprecation warnings we cannot fix from this repo. Each filter is
+# scoped to a specific upstream module so deprecations originating in our own
+# code still surface.
+filterwarnings = [
+    # arxiv-base still uses Pydantic v1 idioms (`.dict()`, `parse_obj`).
+    "ignore::pydantic.PydanticDeprecatedSince20:arxiv.auth.domain",
+    # arxiv-base CSRF helper deprecates itself on import + first use; we have
+    # ~20 in-repo importers, so removing the import path is out of scope here.
+    # (pytest filter syntax splits on ':' so we match by category+module only.)
+    "ignore::DeprecationWarning:arxiv.forms.csrf",
+    # `fire` (transitive dep) imports the removed-in-3.13 stdlib `pipes` module.
+    "ignore::DeprecationWarning:fire.core",
+]
+

--- a/submit_ce/api/submit.py
+++ b/submit_ce/api/submit.py
@@ -97,9 +97,6 @@ class SubmitApi(ABC):
         """
         Load a submission and its history.
 
-        This loads all events for the submission, and generates the most up-to-date representation based on
-        those events.
-
         Parameters
         ----------
         submission_id : str

--- a/submit_ce/domain/__init__.py
+++ b/submit_ce/domain/__init__.py
@@ -5,8 +5,8 @@ from .event import Event
 from .annotation import Comment
 from .meta import License, Classification
 from .preview import Preview
-from .submission import Submission, SubmissionMetadata, Author, Hold, \
-    WithdrawalRequest, UserRequest, CrossListClassificationRequest
+from .submission import Submission, SubmissionMetadata, SubmissionType, Author, \
+    Hold, WithdrawalRequest, UserRequest, CrossListClassificationRequest
 from .uploads import Workspace
 
 __all__ = [
@@ -27,6 +27,7 @@ __all__ = [
     Preview,
     Submission,
     SubmissionMetadata,
+    SubmissionType,
     Author,
     Hold,
     WithdrawalRequest,

--- a/submit_ce/domain/event/legacy.py
+++ b/submit_ce/domain/event/legacy.py
@@ -6,8 +6,7 @@ from submit_ce.api.submit import SubmitApi
 from submit_ce.domain.event.base import EventWithSideEffect
 from submit_ce.domain.exceptions import InvalidEvent
 from submit_ce.domain.submission import Submission
-from submit_ce.domain.uploads import InMemorySubmitFile
-
+from submit_ce.domain.uploads import InMemorySubmitFile, SourceFormat
 
 class Withdraw(EventWithSideEffect):
     """Make a submission for a older style paper withdraw aka `wdr`."""
@@ -15,13 +14,19 @@ class Withdraw(EventWithSideEffect):
     NAME = "withdraw"
     NAMED = "withdrawn"
 
-    comments: str = Field(min_length=10, max_length=400)
-    abstract: str = Field(min_length=10, max_length=1920)
+    paper_id: str
+    """Announced arXiv id of the paper being withdrawn."""
 
-    # TODO How is the wdr associated with the document or original submission?
+    comments: str = Field(min_length=10, max_length=400)
+    """Reason for the withdrawal; appended to the row's Comments."""
+
+    abstract: str = Field(min_length=10, max_length=1920)
+    """Updated abstract for the withdrawal notice."""
 
     def validate(self, submission: Submission) -> None:
-        """Make sure that a reason was provided."""
+        """Make sure that a reason was provided and the paper is announced."""
+        if not self.comments:
+            raise InvalidEvent(self, "Provide a reason for the withdrawal")
         if not submission.is_announced:
             raise InvalidEvent(self, "Submission must already be announced")
 
@@ -35,10 +40,13 @@ class Withdraw(EventWithSideEffect):
                                      withdrawn_file, chunk_size=4096)
 
     def project(self, submission: Submission) -> Submission:
-        """Update the submission status and withdrawal reason."""
+        """Set the withdrawal source state and updated abstract.
+
+        The withdrawal reason (`comments`) is recorded on the classic row via
+        the `WDR_DELIMETER` mechanism during persistence, not here.
+        """
         assert self.created is not None
-        submission.source_format = "withdrawn"
+        submission.source_format = SourceFormat.WITHDRAWN
         submission.is_source_processed = True
-        submission.type = 'wdr'
-        submission.source_format = 'withdrawn'
+        submission.metadata.abstract = self.abstract
         return submission

--- a/submit_ce/domain/event/legacy.py
+++ b/submit_ce/domain/event/legacy.py
@@ -2,9 +2,11 @@
 
 
 from pydantic import Field
+from submit_ce.api.submit import SubmitApi
 from submit_ce.domain.event.base import EventWithSideEffect
 from submit_ce.domain.exceptions import InvalidEvent
 from submit_ce.domain.submission import Submission
+from submit_ce.domain.uploads import InMemorySubmitFile
 
 
 class Withdraw(EventWithSideEffect):
@@ -23,9 +25,19 @@ class Withdraw(EventWithSideEffect):
         if not submission.is_announced:
             raise InvalidEvent(self, "Submission must already be announced")
 
+    def execute(self, api: SubmitApi, submission: Submission) -> None:
+        """Make the file for the withdraw."""
+        content = '%auto-ignore'
+        file_store = api.get_file_store()
+        withdrawn_file = InMemorySubmitFile("withdrawn", content.encode("utf-8"))
+        file_store.delete_all_source_files(str(submission.submission_id))
+        file_store.store_source_file(str(submission.submission_id),
+                                     withdrawn_file, chunk_size=4096)
+
     def project(self, submission: Submission) -> Submission:
         """Update the submission status and withdrawal reason."""
         assert self.created is not None
+        submission.source_format = "withdrawn"
         submission.is_source_processed = True
         submission.type = 'wdr'
         submission.source_format = 'withdrawn'

--- a/submit_ce/domain/event/legacy.py
+++ b/submit_ce/domain/event/legacy.py
@@ -17,7 +17,7 @@ class Withdraw(EventWithSideEffect):
     paper_id: str
     """Announced arXiv id of the paper being withdrawn."""
 
-    comments: str = Field(min_length=10, max_length=400)
+    comment: str = Field(min_length=10, max_length=400)
     """Reason for the withdrawal; appended to the row's Comments."""
 
     abstract: str = Field(min_length=10, max_length=1920)
@@ -25,7 +25,7 @@ class Withdraw(EventWithSideEffect):
 
     def validate(self, submission: Submission) -> None:
         """Make sure that a reason was provided and the paper is announced."""
-        if not self.comments:
+        if not self.comment:
             raise InvalidEvent(self, "Provide a reason for the withdrawal")
         if not submission.is_announced:
             raise InvalidEvent(self, "Submission must already be announced")

--- a/submit_ce/domain/event/legacy.py
+++ b/submit_ce/domain/event/legacy.py
@@ -1,0 +1,32 @@
+"""Events that are intended to be backward compatable with legacy submit 1.5."""
+
+
+from pydantic import Field
+from submit_ce.domain.event.base import EventWithSideEffect
+from submit_ce.domain.exceptions import InvalidEvent
+from submit_ce.domain.submission import Submission
+
+
+class Withdraw(EventWithSideEffect):
+    """Make a submission for a older style paper withdraw aka `wdr`."""
+
+    NAME = "withdraw"
+    NAMED = "withdrawn"
+
+    comments: str = Field(min_length=10, max_length=400)
+    abstract: str = Field(min_length=10, max_length=1920)
+
+    # TODO How is the wdr associated with the document or original submission?
+
+    def validate(self, submission: Submission) -> None:
+        """Make sure that a reason was provided."""
+        if not submission.is_announced:
+            raise InvalidEvent(self, "Submission must already be announced")
+
+    def project(self, submission: Submission) -> Submission:
+        """Update the submission status and withdrawal reason."""
+        assert self.created is not None
+        submission.is_source_processed = True
+        submission.type = 'wdr'
+        submission.source_format = 'withdrawn'
+        return submission

--- a/submit_ce/domain/submission.py
+++ b/submit_ce/domain/submission.py
@@ -242,6 +242,16 @@ class CrossListClassificationRequest(UserRequest):
         return [c.category for c in self.classifications]
 
 
+class SubmissionType(str, Enum):
+    """Submission type; mirrors classic ``arXiv_submissions.type``."""
+
+    NEW = 'new'
+    REPLACEMENT = 'rep'
+    JOURNAL_REFERENCE = 'jref'
+    WITHDRAWAL = 'wdr'
+    CROSS_LIST = 'cross'
+
+
 @dataclass
 class Submission:
     """
@@ -302,6 +312,9 @@ class Submission:
 
     version: int = field(default=1)
 
+    submission_type: Optional[SubmissionType] = field(default=SubmissionType.NEW)
+    """Submission type, mirrors classic arXiv_submissions.type (new/rep/jref/wdr/cross)."""
+
     reason_for_withdrawal: Optional[str] = field(default=None)
     """If an e-print is withdrawn, the submitter is asked to explain why."""
 
@@ -331,6 +344,11 @@ class Submission:
 
     waivers: Dict[str, Waiver] = field(default_factory=dict)
     """Quality control waivers."""
+
+    def __post_init__(self) -> None:
+        """Normalize ``submission_type`` to a :class:`.SubmissionType`."""
+        if self.submission_type is not None:
+            self.submission_type = SubmissionType(self.submission_type)
 
     # Derived / presentation
     #     These should eventually replace creator, since creator

--- a/submit_ce/domain/uploads.py
+++ b/submit_ce/domain/uploads.py
@@ -4,6 +4,7 @@ from typing import Protocol, runtime_checkable, Any
 from typing import List, Optional
 from datetime import datetime
 from enum import Enum
+from io import BytesIO
 
 from pydantic import BaseModel
 from pydantic_core import core_schema
@@ -133,6 +134,19 @@ class SubmitFile(Protocol):
         cls, source_type: Any, handler: Any
     ) -> core_schema.CoreSchema:
         return core_schema.any_schema()
+
+
+class InMemorySubmitFile:
+    """A `SubmitFile` whose contents are held in memory.
+
+    Useful when the system needs to write a file to a workspace without it
+    having been uploaded by a client."""
+
+    def __init__(self, filename: str, content: bytes,
+                 content_type: str = "text/plain") -> None:
+        self.filename = filename
+        self.content_type = content_type
+        self.stream: Any = BytesIO(content)
 
 
 TARGZ_MIMETYPES = frozenset({

--- a/submit_ce/implementations/legacy_implementation/__init__.py
+++ b/submit_ce/implementations/legacy_implementation/__init__.py
@@ -26,7 +26,7 @@ from ...domain.util import get_tzaware_utc_now
 
 from ...domain.event import CreateSubmission
 from ...domain.event.legacy import Withdraw
-from ...domain.exceptions import NoSuchSubmission, NothingToDo
+from ...domain.exceptions import NoSuchSubmission, NothingToDo, SaveError
 from . import db
 
 
@@ -112,8 +112,12 @@ class LegacySubmitImplementation(SubmitApi):
         if not events:
             raise NothingToDo()
         if isinstance(events[0], Withdraw):
-            with self.get_session() as session:
-                return self._save_withdrawal(events[0], session)
+            # BDC I don't love how the Withdraw is handled. I'd perfer if it were done in a side effect
+            if len(events) > 1:
+                raise SaveError("Must save Withdraw as the only item in the list of Events")
+            else:
+                with self.get_session() as session:
+                    return self._save_withdrawal(events[0], session)
         with self.get_session() as session:
             before: Optional[Submission] = None
             existing_events: List[Event] = []

--- a/submit_ce/implementations/legacy_implementation/__init__.py
+++ b/submit_ce/implementations/legacy_implementation/__init__.py
@@ -25,6 +25,7 @@ from ...domain.event.base import Event, EventWithSideEffect
 from ...domain.util import get_tzaware_utc_now
 
 from ...domain.event import CreateSubmission
+from ...domain.event.legacy import Withdraw
 from ...domain.exceptions import NoSuchSubmission, NothingToDo
 from . import db
 
@@ -110,6 +111,9 @@ class LegacySubmitImplementation(SubmitApi):
     def save(self, *events: Event, submission_id: Optional[str] = None) -> Tuple[Submission, List[Event]]:
         if not events:
             raise NothingToDo()
+        if isinstance(events[0], Withdraw):
+            with self.get_session() as session:
+                return self._save_withdrawal(events[0], session)
         with self.get_session() as session:
             before: Optional[Submission] = None
             existing_events: List[Event] = []
@@ -188,6 +192,29 @@ class LegacySubmitImplementation(SubmitApi):
         all_ = sorted(existing_events + committed, key=lambda e: e.created)
         session.commit()
         return after, list(all_)
+
+    def _save_withdrawal(self, event: Withdraw, session) \
+            -> Tuple[Submission, List[Event]]:
+        """Save a `Withdraw`, creating a new ``wdr`` submission.
+
+        A withdrawal creates a brand-new submission seeded from the most recent
+        announced version of ``event.paper_id``. The new row (and its id) must
+        exist before ``execute()`` runs, since the withdrawn source file is
+        written to the new submission's workspace.
+        """
+        event.created = datetime.now(UTC)
+        seed = db.to_submission(db.load_latest_announced(session, event.paper_id))
+
+        # Creates the wdr row and assigns the new submission id onto `after`.
+        consequent, after = db.store_withdrawal(session, event, seed)
+
+        # Now that the new id exists, write the `withdrawn` source file to it.
+        event.execute(self, after)
+        if not event.executed:
+            event.executed = get_tzaware_utc_now()
+
+        session.commit()
+        return after, [consequent]
 
     @override
     def get_service_status(self, impl_data: dict):

--- a/submit_ce/implementations/legacy_implementation/db.py
+++ b/submit_ce/implementations/legacy_implementation/db.py
@@ -48,6 +48,7 @@ from sqlalchemy.orm import Session as SQLAlchemySession
 from sqlalchemy.orm.exc import NoResultFound
 
 from submit_ce.domain.agent import Client, HttpClient
+from submit_ce.domain.event.legacy import Withdraw
 from submit_ce.domain.event.request import CancelRequest, RequestCrossList, RequestWithdrawal
 
 from . import models, interpolate, log
@@ -482,7 +483,7 @@ def load_latest_announced(session: SQLAlchemySession, paper_id: str) \
     return _load(session, paper_id=paper_id, version=max_version)
 
 
-def store_withdrawal(session: SQLAlchemySession, event: Event,
+def store_withdrawal(session: SQLAlchemySession, event: Withdraw,
                      seed: Submission) -> Tuple[Event, Submission]:
     """Create a new ``wdr`` submission row from a `Withdraw` event.
 

--- a/submit_ce/implementations/legacy_implementation/db.py
+++ b/submit_ce/implementations/legacy_implementation/db.py
@@ -42,7 +42,7 @@ import logging
 from arxiv.license import LICENSES
 from pydantic import RootModel
 from retry import retry as _retry
-from sqlalchemy import or_
+from sqlalchemy import or_, func
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session as SQLAlchemySession
 from sqlalchemy.orm.exc import NoResultFound
@@ -56,6 +56,7 @@ from .patch import patch_cross, patch_hold, patch_jref, patch_withdrawal
 from submit_ce import domain
 from submit_ce.domain.uploads import SourceFormat
 from submit_ce.domain import Event, Submission, User, WithdrawalRequest, CrossListClassificationRequest,  License
+from submit_ce.domain.submission import SubmissionType
 from submit_ce.domain.event import SetJournalReference, SetDOI, SetReportNumber, CreateSubmission, Rollback
 from submit_ce.domain.exceptions import NoSuchSubmission
 
@@ -403,13 +404,14 @@ def _cancel_request(session: SQLAlchemySession, event: CancelRequest, before: Su
 
 
 def _load_document_id(session: SQLAlchemySession, paper_id: str, version: int) -> int:
-    logger.debug('get document ID with %s and %s', paper_id, version)
     document_id = session.query(models.Submission.document_id) \
         .filter(models.Submission.doc_paper_id == paper_id) \
         .filter(models.Submission.version == version) \
+        .filter(models.Submission.document_id.isnot(None)) \
+        .order_by(models.Submission.submission_id.desc()) \
         .first()
-    if document_id is None:
-        raise NoSuchSubmission("No submission row matches those parameters")
+    if document_id is None or document_id[0] is None:
+        raise NoSuchSubmission(f"No submission row with paper_id {paper_id} and version {version}")
     return int(document_id[0])
 
 
@@ -462,6 +464,59 @@ def _create_withdrawal(document_id: int, reason: str, paper_id: str,
                             )
     dbs.update_withdrawal(submission, reason, paper_id, version, created)
     return dbs
+
+
+def load_latest_announced(session: SQLAlchemySession, paper_id: str) \
+        -> models.Submission:
+    """Load the most recent announced version row for ``paper_id``.
+
+    Used to seed a withdrawal from the metadata of the latest version.
+    """
+    max_version = session.query(func.max(models.Submission.version)) \
+        .filter(models.Submission.doc_paper_id == paper_id) \
+        .filter(models.Submission.type.in_([models.Submission.NEW_SUBMISSION,
+                                            models.Submission.REPLACEMENT])) \
+        .scalar()
+    if max_version is None:
+        raise NoSuchSubmission(f"No announced submission for paper {paper_id}")
+    return _load(session, paper_id=paper_id, version=max_version)
+
+
+def store_withdrawal(session: SQLAlchemySession, event: Event,
+                     seed: Submission) -> Tuple[Event, Submission]:
+    """Create a new ``wdr`` submission row from a `Withdraw` event.
+
+    Unlike :func:`store_event`, a withdrawal is a side-effecting event that
+    *creates* a new row. We create and flush the row here so the new
+    submission id exists, then hand the projected `after` (carrying the new id)
+    back so the caller can run ``execute()`` against the new workspace.
+    """
+    if event.committed:
+        raise ValueError(f'{event.event_type} {event.event_id} already committed')
+    if event.created is None:
+        raise ValueError('Event creation timestamp not set')
+
+    after = event.apply(seed)
+    doc_id = _load_document_id(session, event.paper_id, after.version)
+    dbs = _create_withdrawal(doc_id, event.comments, event.paper_id,
+                             after.version, after, event.created)
+    dbs.is_withdrawn = 1
+
+    # Flush to assign the autoincrement submission id for the new row.
+    session.add(dbs)
+    session.flush([dbs])
+
+    # The new row owns its own workspace, keyed by the new submission id.
+    after.submission_id = str(dbs.submission_id)
+    dbs.package = str(dbs.submission_id)
+    event.submission_id = str(dbs.submission_id)
+
+    db_event = _new_dbevent(event)
+    session.add(db_event)
+    event.committed = True
+
+    log.handle(session, event, seed, after)
+    return event, after
 
 
 def _create_crosslist(document_id: int, categories: List[str], paper_id: str,
@@ -644,6 +699,7 @@ def to_submission(row: models.Submission,
         secondary_classification=secondary_clsn,
         arxiv_id=row.doc_paper_id,
         version=row.version,
+        submission_type=SubmissionType(row.type) if row.type else None,
         proxy=proxy
     )
     if row.sticky_status == row.ON_HOLD or row.status == row.ON_HOLD:

--- a/submit_ce/implementations/legacy_implementation/db.py
+++ b/submit_ce/implementations/legacy_implementation/db.py
@@ -498,7 +498,7 @@ def store_withdrawal(session: SQLAlchemySession, event: Event,
 
     after = event.apply(seed)
     doc_id = _load_document_id(session, event.paper_id, after.version)
-    dbs = _create_withdrawal(doc_id, event.comments, event.paper_id,
+    dbs = _create_withdrawal(doc_id, event.comment, event.paper_id,
                              after.version, after, event.created)
     dbs.is_withdrawn = 1
 

--- a/submit_ce/implementations/legacy_implementation/models.py
+++ b/submit_ce/implementations/legacy_implementation/models.py
@@ -256,6 +256,7 @@ class Submission(Base):    # type: ignore
         self.status = Submission.PROCESSING_SUBMISSION
         reason = f"{Submission.WDR_DELIMETER}{reason}"
         self.comments = self.comments.rstrip('. ') + reason
+        self.source_flags = '1'
 
     def update_cross(self, submission: domain.Submission,
                      categories: List[str], paper_id: str, version: int,

--- a/submit_ce/ui/conftest.py
+++ b/submit_ce/ui/conftest.py
@@ -478,7 +478,7 @@ def published_submission(app, authorized_user):
             else:
                 paper_id = "1234.56789"
 
-            db_submission = session.query(classic.Submission).get(submission.submission_id)
+            db_submission = session.get(classic.Submission, submission.submission_id)
             if not db_submission:
                 raise RuntimeError(f"No db row for {submission.submission_id}")
             db_submission.status = 7  # published

--- a/submit_ce/ui/controllers/tests/test_withdraw.py
+++ b/submit_ce/ui/controllers/tests/test_withdraw.py
@@ -1,0 +1,97 @@
+"""Tests for the withdraw submission UI controller."""
+from http import HTTPStatus as status
+
+from flask import current_app
+import pytest
+
+import arxiv.db.models as classic
+from arxiv.db import Session
+
+from submit_ce.ui.tests.csrf_util import parse_csrf_token
+
+
+def test_wdr_no_submission(app, authorized_client):
+    """GET on a submission_id that doesn't exist returns NOT_FOUND."""
+    response = authorized_client.get('/1234/withdraw')
+    assert response.status_code == status.NOT_FOUND
+
+
+def test_wdr_submission_not_published(app, authorized_client, submitted_submission):
+    """Withdraw on a finalized-but-not-announced submission is rejected.
+
+    The controller flashes failure and 303-redirects to create_submission.
+    """
+    sid = submitted_submission.submission_id
+    response = authorized_client.get(f'/{sid}/withdraw')
+    assert response.status_code == status.SEE_OTHER
+    assert '/' in response.headers.get('Location', '')
+
+
+def test_wdr_submission_not_owned_by_user(app, authorized_client, published_submission):
+    """A submission owned by a different user is not editable by us.
+
+    Achieved by flipping the DB row's submitter_id to a non-matching value;
+    the route's `is_owner` authorizer then returns False and `scoped` answers
+    with a non-success status (typically FORBIDDEN).
+    """
+    submission, _paper_id = published_submission
+    sid = submission.submission_id
+
+    with app.app_context():
+        with Session() as session:
+            row = session.query(classic.Submission).get(sid)
+            row.submitter_id = 99999  # not the test user (user_id=10)
+            session.add(row)
+            session.commit()
+
+        response = authorized_client.get(f'/{sid}/withdraw')
+
+    assert response.status_code in (
+        status.FORBIDDEN, status.FOUND, status.SEE_OTHER, status.UNAUTHORIZED,
+    ), f"expected an unauthorized/forbidden/redirect, got {response.status_code}"
+
+
+def test_wdr_published_submission_succeeds(app, authorized_client, published_submission):
+    """GET on a published submission renders the withdrawal form, POST creates a wdr row."""
+    submission, paper_id = published_submission
+    sid = submission.submission_id
+
+    get1 = authorized_client.get(f'/{sid}/withdraw')
+    assert get1.status_code == status.OK
+    assert b'withdrawal' in get1.data.lower() or b'Withdraw' in get1.data
+
+    post1 = authorized_client.post(
+        f'/{sid}/withdraw',
+        data={
+            'csrf_token': parse_csrf_token(get1),
+            'withdrawal_reason': f'Test WDR from {__file__}, found a serious error in section 3.',
+            'confirmed': 'y',
+        },
+    )
+    assert post1.status_code == status.SEE_OTHER
+
+    with app.app_context():
+        with Session() as session:
+            original = session.query(classic.Submission).get(sid)
+            assert original is not None, "original submission row should still exist"
+            wdr_rows = session.query(classic.Submission).filter(
+                classic.Submission.doc_paper_id == paper_id,
+                classic.Submission.type == 'wdr',
+            ).all()
+            assert len(wdr_rows) == 1, \
+                f"expected exactly one 'wdr' row for {paper_id}, got {len(wdr_rows)}"
+            wdr = wdr_rows[0]
+            assert wdr.submission_id != sid, \
+                "withdrawal row should be a new row, not the original submission"
+            assert wdr.is_withdrawn == 1
+            assert wdr.must_process == 0
+            assert wdr.is_single_file == 1
+            assert wdr.source_format == 'withdrawn'
+
+            workspace = app.api.get_file_store().get_workspace(wdr.submission_id)
+            assert workspace
+            assert workspace.file_count == 1
+            file = workspace.files[0]
+            assert file.name == "withdrawn"
+            with app.api.get_file_store().get_source_file(wdr.submission_id, file.path) as fh:
+                assert fh.read() == '%auto-ignore'

--- a/submit_ce/ui/controllers/tests/test_withdraw.py
+++ b/submit_ce/ui/controllers/tests/test_withdraw.py
@@ -1,13 +1,11 @@
 """Tests for the withdraw submission UI controller."""
 from http import HTTPStatus as status
 
-from flask import current_app
-import pytest
-
 import arxiv.db.models as classic
 from arxiv.db import Session
 
 from submit_ce.ui.tests.csrf_util import parse_csrf_token
+from submit_ce.ui.conftest import mocked_file_store
 
 
 def test_wdr_no_submission(app, authorized_client):
@@ -56,6 +54,9 @@ def test_wdr_published_submission_succeeds(app, authorized_client, published_sub
     submission, paper_id = published_submission
     sid = submission.submission_id
 
+    # Use an in-memory store that actually retains the withdrawn source file.
+    mocked_file_store(app)
+
     get1 = authorized_client.get(f'/{sid}/withdraw')
     assert get1.status_code == status.OK
     assert b'withdrawal' in get1.data.lower() or b'Withdraw' in get1.data
@@ -64,7 +65,8 @@ def test_wdr_published_submission_succeeds(app, authorized_client, published_sub
         f'/{sid}/withdraw',
         data={
             'csrf_token': parse_csrf_token(get1),
-            'withdrawal_reason': f'Test WDR from {__file__}, found a serious error in section 3.',
+            'comment': f'Test WDR from {__file__}, found a serious error in section 3.',
+            'abstract': 'This is the updated abstract for the withdrawal notice.',
             'confirmed': 'y',
         },
     )
@@ -85,13 +87,14 @@ def test_wdr_published_submission_succeeds(app, authorized_client, published_sub
                 "withdrawal row should be a new row, not the original submission"
             assert wdr.is_withdrawn == 1
             assert wdr.must_process == 0
-            assert wdr.is_single_file == 1
+            assert wdr.source_flags == '1'
             assert wdr.source_format == 'withdrawn'
 
-            workspace = app.api.get_file_store().get_workspace(wdr.submission_id)
+            wdr_sid = str(wdr.submission_id)
+            workspace = app.api.get_file_store().get_workspace(wdr_sid)
             assert workspace
             assert workspace.file_count == 1
             file = workspace.files[0]
             assert file.name == "withdrawn"
-            with app.api.get_file_store().get_source_file(wdr.submission_id, file.path) as fh:
-                assert fh.read() == '%auto-ignore'
+            with app.api.get_file_store().get_source_file(wdr_sid, file.path).open() as fh:
+                assert fh.read() == b'%auto-ignore'

--- a/submit_ce/ui/controllers/tests/test_withdraw.py
+++ b/submit_ce/ui/controllers/tests/test_withdraw.py
@@ -37,7 +37,7 @@ def test_wdr_submission_not_owned_by_user(app, authorized_client, published_subm
 
     with app.app_context():
         with Session() as session:
-            row = session.query(classic.Submission).get(sid)
+            row = session.get(classic.Submission, sid)
             row.submitter_id = 99999  # not the test user (user_id=10)
             session.add(row)
             session.commit()
@@ -74,7 +74,7 @@ def test_wdr_published_submission_succeeds(app, authorized_client, published_sub
 
     with app.app_context():
         with Session() as session:
-            original = session.query(classic.Submission).get(sid)
+            original = session.get(classic.Submission, sid)
             assert original is not None, "original submission row should still exist"
             wdr_rows = session.query(classic.Submission).filter(
                 classic.Submission.doc_paper_id == paper_id,

--- a/submit_ce/ui/controllers/withdraw.py
+++ b/submit_ce/ui/controllers/withdraw.py
@@ -71,7 +71,7 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
     if method == 'GET':
         params.setdefault("confirmed", False)
         params.setdefault("abstract", submission.metadata.abstract)
-        params.setdefault("comments", submission.metadata.comments)
+        params.setdefault("comment", submission.metadata.comments)
 
     form = WithdrawalForm(params)
     response_data = {
@@ -87,9 +87,11 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
         return response_data, status.OK, {}
     elif method == 'POST' and form.validate() and form.data['confirmed']:
         cmd = Withdraw(paper_id=submission_to_wdr.arxiv_id,
-                       comments=form.comment.data, abstract=form.abstract.data,
+                       comment=form.comment.data, abstract=form.abstract.data,
                        creator=submitter, client=client)
-        if validate_command(form, cmd, submission_to_wdr):
+        if not validate_command(form, cmd, submission_to_wdr):
+            return response_data, status.BAD_REQUEST, {}
+        else:
             try:
                 submission_to_wdr, _ = current_app.api.save(cmd)
                 response_data['require_confirmation'] = True

--- a/submit_ce/ui/controllers/withdraw.py
+++ b/submit_ce/ui/controllers/withdraw.py
@@ -8,13 +8,14 @@ from arxiv.auth.domain import Session
 from flask import url_for, current_app
 from markupsafe import Markup
 from werkzeug.datastructures import MultiDict
-from werkzeug.exceptions import InternalServerError
+from werkzeug.exceptions import InternalServerError, NotFound
 from wtforms.fields import TextAreaField, BooleanField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, Length
 
 from arxiv.base import alerts
 from arxiv.forms import csrf
-from submit_ce.domain.event import RequestWithdrawal
+from submit_ce.domain.event import FinalizeSubmission
+from submit_ce.domain.event.legacy import Withdraw
 
 from .util import FieldMixin, validate_command
 from submit_ce.ui.backend import get_submission
@@ -30,26 +31,36 @@ Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 class WithdrawalForm(csrf.CSRFForm, FieldMixin):
     """Submit a withdrawal request."""
 
-    withdrawal_reason = TextAreaField(
-        'Reason for withdrawal',
-        validators=[DataRequired()],
-        description=f'Limit {RequestWithdrawal.MAX_LENGTH} characters'
+    comment = TextAreaField(
+        'Comment',
+        validators=[DataRequired(), Length(min=10, max=400)],
+        description='Limit 400 characters'
+    )
+    abstract = TextAreaField(
+        'Abstract',
+        validators=[DataRequired(), Length(min=10, max=1920)],
+        description='Limit 1920 characters'
     )
     confirmed = BooleanField('Confirmed',
                              false_values=('false', False, 0, '0', ''))
 
 
+def _stay_on_page(submission_to_wdr):
+    loc = url_for('ui.withdraw', submission_id=submission_to_wdr.submission_id)
+    return {}, status.SEE_OTHER, {'Location': loc}
+
+
 def request_withdrawal(method: str, params: MultiDict, session: Session,
                        submission_id: str, **kwargs) -> Response:
     """Request withdrawal of a paper."""
+
     submitter, client = user_and_client_from_session(session)
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
 
     # Will raise NotFound if there is no such submission.
-    submission, _ = get_submission(submission_id)
-
+    submission_to_wdr, _ = get_submission(submission_id)
     # The submission must be announced for this to be a withdrawal request.
-    if not submission.is_announced:
+    if not submission_to_wdr.is_announced:
         alerts.flash_failure(Markup(
             "Submission must first be announced. See "
             "<a href='https://arxiv.org/help/withdraw'>the arXiv help pages"
@@ -58,66 +69,40 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
         loc = url_for('ui.create_submission')
         return {}, status.SEE_OTHER, {'Location': loc}
 
-    # The form should be prepopulated based on the current state of the
-    # submission.
+    if method != 'GET' and method != 'POST':
+        return {}, status.OK
+
+    submission = submission_to_wdr
     if method == 'GET':
-        params = MultiDict({})
+        params.setdefault("confirmed", False)
+        params.setdefault("abstract", submission.metadata.abstract)
+        params.setdefault("comments", submission.metadata.comments)
 
-
-    params.setdefault("confirmed", False)
     form = WithdrawalForm(params)
     response_data = {
-        'submission_id': submission_id,
+        'submission_id': submission.submission_id,
         'submission': submission,
         'form': form,
-        'submission_history': [], # abs macro expects this
     }
-    if method == 'GET':
-        return response_data, status.OK, {}
-
-    cmd = RequestWithdrawal(reason=form.withdrawal_reason.data,
-                            creator=submitter, client=client)
-    if method == 'POST' and form.validate() \
-       and form.confirmed.data \
-       and validate_command(form, cmd, submission, 'withdrawal_reason'):
-        try:
-            # Save the events created during form validation.
-            submission, _ = current_app.api.save(cmd, submission_id=submission_id)
-
-            #TODO Make sure that the withdraw command puts the submission in a state similar to a legacy wdr
-
-            # From Submit.pm
-            # status should be 8
-            # should be submitted
-            # needs to do "submit_source # will create auto-ignore file"
-            # submit_source does:
-            """
-            $self->must_process(0);
-            $self->submit_withdrawal_source if $self->type eq 'wdr';
-            $self->pack_source;
-            $self->set_source_size;
-            """
-            """
-            submit_withdrawal_source does:
-            my $self = shift;
-            # write to auto_ignore file
-            my $content = '%auto-ignore';
-            my $file    = $self->files->sub_src_dir . 'withdrawn';
-            io($file)->assert->print($content);
-            chmod( 0664, $file );
-            $self->is_withdrawn(1);
-            $self->is_single_file(1);
-            $self->source_format('withdrawn');
-            $self->update;
-            """
-
-            # Success! Send user back to the submission page.
-            alerts.flash_success("Withdrawal request submitted.")
-            status_url = url_for('ui.create_submission')
-            return {}, status.SEE_OTHER, {'Location': status_url}
-        except SaveError as ex:
-            raise InternalServerError(response_data) from ex
-    else:
+    if method == 'GET' or \
+       (method =='POST' and not form.validate()) or \
+       (method =='POST' and form.validate() and not form.data['confirmed']):
         response_data['require_confirmation'] = True
 
-    return response_data, status.OK, {}
+        return response_data, status.OK, {}
+    elif method == 'POST' and form.validate() and form.data['confirmed']:
+        cmd = Withdraw(paper_id=submission_to_wdr.arxiv_id,
+                       comments=form.comment.data, abstract=form.abstract.data,
+                       creator=submitter, client=client)
+        if validate_command(form, cmd, submission_to_wdr):
+            try:
+                submission_to_wdr, _ = current_app.api.save(cmd)
+                response_data['require_confirmation'] = True
+                alerts.flash_success("Withdrawal request submitted.")
+                status_url = url_for('ui.create_submission')
+                return {}, status.SEE_OTHER, {'Location': status_url}
+            except SaveError as ex:
+                raise InternalServerError(response_data) from ex
+    else:
+        # kind of unexpected, we should not get here?
+        return response_data, status.OK, {}

--- a/submit_ce/ui/controllers/withdraw.py
+++ b/submit_ce/ui/controllers/withdraw.py
@@ -83,6 +83,34 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
         try:
             # Save the events created during form validation.
             submission, _ = current_app.api.save(cmd, submission_id=submission_id)
+
+            #TODO Make sure that the withdraw command puts the submission in a state similar to a legacy wdr
+
+            # From Submit.pm
+            # status should be 8
+            # should be submitted
+            # needs to do "submit_source # will create auto-ignore file"
+            # submit_source does:
+            """
+            $self->must_process(0);
+            $self->submit_withdrawal_source if $self->type eq 'wdr';
+            $self->pack_source;
+            $self->set_source_size;
+            """
+            """
+            submit_withdrawal_source does:
+            my $self = shift;
+            # write to auto_ignore file
+            my $content = '%auto-ignore';
+            my $file    = $self->files->sub_src_dir . 'withdrawn';
+            io($file)->assert->print($content);
+            chmod( 0664, $file );
+            $self->is_withdrawn(1);
+            $self->is_single_file(1);
+            $self->source_format('withdrawn');
+            $self->update;
+            """
+
             # Success! Send user back to the submission page.
             alerts.flash_success("Withdrawal request submitted.")
             status_url = url_for('ui.create_submission')

--- a/submit_ce/ui/controllers/withdraw.py
+++ b/submit_ce/ui/controllers/withdraw.py
@@ -8,13 +8,12 @@ from arxiv.auth.domain import Session
 from flask import url_for, current_app
 from markupsafe import Markup
 from werkzeug.datastructures import MultiDict
-from werkzeug.exceptions import InternalServerError, NotFound
+from werkzeug.exceptions import InternalServerError
 from wtforms.fields import TextAreaField, BooleanField
 from wtforms.validators import DataRequired, Length
 
 from arxiv.base import alerts
 from arxiv.forms import csrf
-from submit_ce.domain.event import FinalizeSubmission
 from submit_ce.domain.event.legacy import Withdraw
 
 from .util import FieldMixin, validate_command
@@ -52,9 +51,8 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
     submitter, client = user_and_client_from_session(session)
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
 
-    # Will raise NotFound if there is no such submission.
     submission_to_wdr, _ = get_submission(submission_id)
-    # The submission must be announced for this to be a withdrawal request.
+
     if not submission_to_wdr.is_announced:
         alerts.flash_failure(Markup(
             "Submission must first be announced. See "
@@ -79,12 +77,15 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
         'submission': submission,
         'form': form,
     }
-    if method == 'GET' or \
-       (method =='POST' and not form.validate()) or \
+
+    if method == 'GET':
+        return response_data, status.OK, {}
+
+    elif (method =='POST' and not form.validate()) or \
        (method =='POST' and form.validate() and not form.data['confirmed']):
         response_data['require_confirmation'] = True
-
         return response_data, status.OK, {}
+
     elif method == 'POST' and form.validate() and form.data['confirmed']:
         cmd = Withdraw(paper_id=submission_to_wdr.arxiv_id,
                        comment=form.comment.data, abstract=form.abstract.data,

--- a/submit_ce/ui/controllers/withdraw.py
+++ b/submit_ce/ui/controllers/withdraw.py
@@ -45,11 +45,6 @@ class WithdrawalForm(csrf.CSRFForm, FieldMixin):
                              false_values=('false', False, 0, '0', ''))
 
 
-def _stay_on_page(submission_to_wdr):
-    loc = url_for('ui.withdraw', submission_id=submission_to_wdr.submission_id)
-    return {}, status.SEE_OTHER, {'Location': loc}
-
-
 def request_withdrawal(method: str, params: MultiDict, session: Session,
                        submission_id: str, **kwargs) -> Response:
     """Request withdrawal of a paper."""
@@ -70,7 +65,7 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
         return {}, status.SEE_OTHER, {'Location': loc}
 
     if method != 'GET' and method != 'POST':
-        return {}, status.OK
+        return {}, status.OK, {}
 
     submission = submission_to_wdr
     if method == 'GET':

--- a/submit_ce/ui/routes/flow_control.py
+++ b/submit_ce/ui/routes/flow_control.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus as status
 from functools import wraps
-from typing import Optional, Callable, Union, Dict, List, Tuple
+from typing import Optional, Callable, Union, Dict, List, Tuple, assert_never
 from typing_extensions import Literal
 import logging
 
@@ -14,6 +14,7 @@ from werkzeug.exceptions import BadRequest
 from arxiv.base import alerts
 from submit_ce.domain import Submission, Event
 
+from submit_ce.domain.submission import SubmissionType
 from submit_ce.ui.workflow import NewSubmissionWorkflow, ReplacementWorkflow
 from submit_ce.ui.workflow.stages import Stage
 from submit_ce.ui.workflow.processor import WorkflowProcessor
@@ -104,14 +105,29 @@ def get_workflow(submission: Optional[Submission],
                  events: List[Event]) -> WorkflowProcessor:
     """Guesses the workflow based on the submission and its version."""
     if submission is None:
-        raise RuntimeError("Cannot figure out workflow without a submission")
-    if submission.version > 1:
-        return WorkflowProcessor(ReplacementWorkflow, submission, events, get_seen())
-    else:
-        return WorkflowProcessor(NewSubmissionWorkflow, submission, events, get_seen())
-    # todo need cross workflow
-    # todo need jref workflow
-    # todo need doi workflow
+          raise RuntimeError("Cannot figure out workflow without a submission")
+
+    match submission.submission_type:
+        case SubmissionType.NEW:
+            if submission.version > 1:
+                raise RuntimeError(
+                    "Cannot do a new submission on a submission with version > 1")
+            return WorkflowProcessor(NewSubmissionWorkflow, submission, events, get_seen())
+        case SubmissionType.REPLACEMENT:
+            return WorkflowProcessor(ReplacementWorkflow, submission, events, get_seen())
+        case SubmissionType.WITHDRAWAL:
+            raise RuntimeError("Withdraw is not workflow controlled.")
+        case SubmissionType.JOURNAL_REFERENCE:
+            # todo need jref workflow
+            # todo need doi workflow
+            raise RuntimeError("Journal ref workflow not yet implemented")
+        case SubmissionType.CROSS_LIST:
+            # todo need cross workflow
+            raise RuntimeError("Cross-list workflow not yet implemented")
+        case None:
+            raise RuntimeError("Submission has no submission_type")
+        case _:
+            assert_never(submission.submission_type)
 
 
 def to_stage(stage: Optional[Stage], ident: str) -> Response:

--- a/submit_ce/ui/templates/submit/withdraw.html
+++ b/submit_ce/ui/templates/submit/withdraw.html
@@ -30,7 +30,7 @@
       submission.metadata.abstract,
       submission.created,
       submission.primary_classification,
-      comments = comments_preview(submission.metadata.comments, form.withdrawal_reason.data),
+      comments = comments_preview(submission.metadata.comments, form.comment.data),
       msc_class = submission.metadata.msc_class,
       acm_class = submission.metadata.acm_class,
       journal_ref = submission.metadata.journal_ref,
@@ -61,10 +61,10 @@
     <div class="columns">
       <div class="column">
         {{ form.csrf_token }}
-        {% with field = form.withdrawal_reason %}
+        {% for field in [form.comment, form.abstract] %}
         <div class="field">
           <div class="control">
-            <label class="label" for="withdrawal_reason">{{ field.label.text }} (required) <a class="help-bubble" href="{{ url_for('help_withdraw') }}"><i class="fa fa-question-circle is-info"></i><div class="bubble-text">Specific reason for withdrawal will be placed in the Comments display for your article.</div></a></label>
+            <label class="label" for="{{ field.id }}">{{ field.label.text }} (required) <a class="help-bubble" href="{{ url_for('help_withdraw') }}"><i class="fa fa-question-circle is-info"></i><div class="bubble-text">Specific reason for withdrawal will be placed in the Comments display for your article.</div></a></label>
             {% if field.errors %}
               <div class="help is-danger field-error">
                 {% for error in field.errors %}
@@ -84,7 +84,7 @@
             {% endif %}
           </div>
         </div>
-        {% endwith %}
+        {% endfor %}
 
       </div>
       <div class="column" style="align-self: flex-end">

--- a/submit_ce/ui/workflow/conditions.py
+++ b/submit_ce/ui/workflow/conditions.py
@@ -34,6 +34,12 @@ def has_secondary(submission: Submission, events: List[Event]) -> bool:
     return len(submission.secondary_classification) > 0
 
 
+def has_abstract(submission: Submission, events: List[Event]) -> bool:
+    return bool(submission.metadata.abstract)
+
+def has_comment(submission: Submission, events: List[Event]) -> bool:
+    return bool(submission.metadata.comments)
+
 def has_files(submission: Submission, events: List[Event]) -> bool:
     """Determine if the submission has any files."""
     return submission.uncompressed_size > 0

--- a/submit_ce/ui/workflow/tests/test_withdraw_workflow.py
+++ b/submit_ce/ui/workflow/tests/test_withdraw_workflow.py
@@ -7,6 +7,7 @@ import arxiv.db.models as classic
 
 
 from submit_ce.ui.tests.csrf_util import parse_csrf_token
+from submit_ce.ui.conftest import mocked_file_store
 
 
 def test_withdrawl_workflow(app, authorized_client, published_submission):
@@ -14,6 +15,8 @@ def test_withdrawl_workflow(app, authorized_client, published_submission):
     client = authorized_client
     submission, paper_id = published_submission
     submission_id = submission.submission_id
+    # In-memory store so the withdrawn source file can actually be written.
+    mocked_file_store(app)
     def _parse_csrf_token(response):
         return parse_csrf_token(response)
 
@@ -26,16 +29,18 @@ def test_withdrawl_workflow(app, authorized_client, published_submission):
     assert b'Request withdrawal' in response.data
     token = _parse_csrf_token(response)
 
-    # Set the withdrawal reason, but make it huge.
-    request_data = {'withdrawal_reason': 'This is the reason' * 400,
+    # Set the withdrawal comment, but make it too long.
+    request_data = {'comment': 'This is the reason' * 400,
+                    'abstract': 'This is the updated abstract.',
                     'csrf_token': token}
     response = client.post(endpoint, data=request_data,
                                 )
     assert response.status_code == status.OK
     token = _parse_csrf_token(response)
 
-    # Set the withdrawal reason to something reasonable (ha).
-    request_data = {'withdrawal_reason': 'This is the reason',
+    # Set the withdrawal comment and abstract to something reasonable (ha).
+    request_data = {'comment': 'This is the reason',
+                    'abstract': 'This is the updated abstract.',
                     'csrf_token': token}
     response = client.post(endpoint, data=request_data,
                                 )


### PR DESCRIPTION

Fixes how withdraw works, adds `submission_type` to domain. 

The withdraw is created to produces a submission that will work with publish to do a withdraw that is very similar to what 1.5 submit does.

Adds `submission_type` to domain `Submission` from `arXiv_submissions.type`. NG lacked this due to working differently around how submissions/documents work.

Adds a enum for `SubmissionType`.

Adds test of withdraw.

SUBMISSION-130