### PR TITLE
SUBMISSION-169: Ensure that call to preflight is using a fresh tar archive.

### DIFF
--- a/submit_ce/api/file_store.py
+++ b/submit_ce/api/file_store.py
@@ -141,6 +141,21 @@ class SubmissionFileStore(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_source_package(self, submission_id: str) -> FileObj:
+        """Retrieve the persisted ``<submission_id>.tar.gz`` source package.
+
+        Returns a :class:`~arxiv.files.FileObj` for the archive last
+        written by :meth:`write_source_package`, or
+        :class:`~arxiv.files.FileDoesNotExist` if none has been written.
+        Callers that want a *fresh* archive built under the submission
+        lock should dispatch ``BuildSourcePackage`` (which calls
+        :meth:`write_source_package` inside the locked transaction) and
+        then read the result with this method, rather than calling the
+        unlocked :meth:`build_source_package` directly.
+        """
+        pass
+
+    @abstractmethod
     def store_preview(self, submission_id: str, content: IO[bytes], chunk_size: int = 4096) -> str:
         """Store a preview PDF for a submission.
 

--- a/submit_ce/api/file_store.py
+++ b/submit_ce/api/file_store.py
@@ -108,6 +108,39 @@ class SubmissionFileStore(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def build_source_package(self, submission_id: str) -> bytes:
+        """Build a fresh .tar.gz of the current source files in memory.
+
+        Returns the gzipped tarball bytes for the current contents of
+        the submission's ``src/`` directory, without touching the
+        persisted ``<submission_id>.tar.gz``. Intended for callers that
+        need the bytes themselves (e.g., the Download Source Package
+        controller).
+        """
+        pass
+
+    @abstractmethod
+    def write_source_package(self, submission_id: str) -> None:
+        """Build the source package and write it to the canonical path.
+
+        Overwrites any existing ``<submission_id>.tar.gz`` with a fresh
+        archive built from the current source files. Intended for
+        callers that need the canonical path on the bucket to point at
+        current source (e.g., the preflight API call).
+        """
+        pass
+
+    @abstractmethod
+    def delete_source_package(self, submission_id: str) -> None:
+        """Delete the persisted ``<submission_id>.tar.gz`` if it exists.
+
+        Used to invalidate the cached archive when source files
+        change, so a downstream service can't be handed a stale
+        snapshot.
+        """
+        pass
+
+    @abstractmethod
     def store_preview(self, submission_id: str, content: IO[bytes], chunk_size: int = 4096) -> str:
         """Store a preview PDF for a submission.
 

--- a/submit_ce/domain/event/file.py
+++ b/submit_ce/domain/event/file.py
@@ -24,6 +24,15 @@ def _common_file_change_execute(api: SubmitApi, submission: Submission) -> None:
     Any change to the source workspace invalidates the analysis chain
     that was built from the previous state of the files:
 
+    * **source_package** -- the persisted ``<id>.tar.gz`` snapshot of
+      the source directory. The preflight API
+      (``CompileApiService.start_preflight``) hands this path to
+      tex2pdf as the ``source`` query param, so if it lingers past a
+      file change tex2pdf scans a stale snapshot and Review Files
+      shows the old file list. We delete it here; the next
+      ``start_preflight`` call rebuilds it fresh from ``src/``. (The
+      same archive is rebuilt by ``compile_at_gcp.py`` on a successful
+      compile, so the compile-time path is unaffected.)
     * **preflight** -- the per-file scan that detects compiler, top-level
       TeX, issues, etc. Must be re-run against the new file list.
     * **user_decisions** -- captures the user's selections (source_file,
@@ -43,13 +52,19 @@ def _common_file_change_execute(api: SubmitApi, submission: Submission) -> None:
     (UploadArchive / UploadFiles / RemoveFiles / RemoveAllFiles) get
     consistent invalidation. Skipping any of these leads to stale data
     being shown on Review Files even though the workspace itself is
-    current. The submission-package ``<id>.tar.gz`` is intentionally
-    NOT deleted here -- it represents the source that last successfully
-    compiled, and gets overwritten by ``compile_at_gcp.py`` on the next
-    successful compile.
+    current.
+
+    Note: we delete here (cheap, one bucket call per event) rather
+    than rebuild here. Rebuilding the tar inside each file event
+    would be quadratic for multi-file uploads -- N AddFiles events
+    would each download all N files and reupload, for O(N^2) bucket
+    traffic, with only the last build mattering. Lazy rebuild in
+    ``start_preflight`` keeps the cost at one build per preflight
+    call regardless of how many file events preceded it.
     """
     file_store = api.get_file_store()
     sid = str(submission.submission_id)
+    file_store.delete_source_package(sid)
     file_store.delete_preflight(sid)
     file_store.delete_user_decisions(sid)
     file_store.delete_directives(sid)

--- a/submit_ce/domain/event/file.py
+++ b/submit_ce/domain/event/file.py
@@ -19,10 +19,41 @@ def _common_file_change_project(submission: Submission) -> None:
 
 
 def _common_file_change_execute(api: SubmitApi, submission: Submission) -> None:
-    """Common changes during `execute` when any file change happens."""
+    """Common changes during `execute` when any file change happens.
+
+    Any change to the source workspace invalidates the analysis chain
+    that was built from the previous state of the files:
+
+    * **preflight** -- the per-file scan that detects compiler, top-level
+      TeX, issues, etc. Must be re-run against the new file list.
+    * **user_decisions** -- captures the user's selections (source_file,
+      compiler, marked-for-deletion) made on the Review Files step.
+      Those selections may reference files that no longer exist after
+      the change, so we drop them and let the user re-select.
+    * **directives** -- the combined preflight + user_decisions output
+      that drives compilation. With both of its inputs invalidated,
+      this is also stale.
+    * **preview** -- the compiled PDF that was produced from the
+      previous source.
+
+    Submit 1.5 had separate ``clear_preflight`` and
+    ``clear_directives_data`` routines in ``Submit.pm`` that were
+    called from various file-change paths; this is the 2.0 equivalent
+    consolidated into one place so all four file events
+    (UploadArchive / UploadFiles / RemoveFiles / RemoveAllFiles) get
+    consistent invalidation. Skipping any of these leads to stale data
+    being shown on Review Files even though the workspace itself is
+    current. The submission-package ``<id>.tar.gz`` is intentionally
+    NOT deleted here -- it represents the source that last successfully
+    compiled, and gets overwritten by ``compile_at_gcp.py`` on the next
+    successful compile.
+    """
     file_store = api.get_file_store()
-    file_store.delete_preflight(str(submission.submission_id))
-    file_store.delete_preview(str(submission.submission_id))
+    sid = str(submission.submission_id)
+    file_store.delete_preflight(sid)
+    file_store.delete_user_decisions(sid)
+    file_store.delete_directives(sid)
+    file_store.delete_preview(sid)
 
 
 class UploadArchive(EventWithSideEffect):

--- a/submit_ce/domain/event/process.py
+++ b/submit_ce/domain/event/process.py
@@ -123,6 +123,38 @@ class StartPreflight(EventWithSideEffect):
         return submission
 
 
+class BuildSourcePackage(EventWithSideEffect):
+    """Build the canonical ``<id>.tar.gz`` source package under the lock.
+
+    The tar is assembled from the submission's current source files. By
+    running as an :class:`.EventWithSideEffect`, ``SubmitApi.save`` holds the
+    submission row lock for the duration of :meth:`execute`, so a concurrent
+    upload or delete cannot change the file set mid-build and produce a
+    package that mixes files which never coexisted on the submission. See the
+    "critical section" design note in ``CLAUDE.md``.
+
+    Carries no extra data (the side effect is the persisted ``<id>.tar.gz``),
+    so it serializes and replays like any base event.
+    """
+
+    NAME = "build source package"
+    NAMED = "built source package"
+
+    def validate(self, submission: Submission) -> None:
+        """The submission must exist to have a source package built."""
+        if not submission.submission_id:
+            raise InvalidEvent(
+                self, "Cannot build source package: submission has no id.")
+
+    def execute(self, api: 'SubmitApi', submission: Submission) -> None:
+        """Build and persist ``<id>.tar.gz`` from current source, under lock."""
+        api.get_file_store().write_source_package(submission.submission_id)
+
+    def project(self, submission: Submission) -> Submission:
+        """No submission-state change; the side effect is the stored tar."""
+        return submission
+
+
 class StartDirectives(EventWithSideEffect):
     """Start directives generation for a submission."""
 

--- a/submit_ce/implementations/__init__.py
+++ b/submit_ce/implementations/__init__.py
@@ -88,6 +88,15 @@ class NullFileStore(SubmissionFileStore):
     def does_source_exist(self, submission_id: str) -> bool:
         return False
 
+    def build_source_package(self, submission_id: str) -> bytes:
+        return b""
+
+    def write_source_package(self, submission_id: str) -> None:
+        pass
+
+    def delete_source_package(self, submission_id: str) -> None:
+        pass
+
     def get_full_submission_path(self, submission_id: str) -> str:
         return ""
 

--- a/submit_ce/implementations/__init__.py
+++ b/submit_ce/implementations/__init__.py
@@ -97,6 +97,10 @@ class NullFileStore(SubmissionFileStore):
     def delete_source_package(self, submission_id: str) -> None:
         pass
 
+    def get_source_package(self, submission_id: str) -> FileObj:
+        from arxiv.files import FileDoesNotExist
+        return FileDoesNotExist(f"{submission_id}.tar.gz")
+
     def get_full_submission_path(self, submission_id: str) -> str:
         return ""
 

--- a/submit_ce/implementations/compile/compile_api_service.py
+++ b/submit_ce/implementations/compile/compile_api_service.py
@@ -107,15 +107,22 @@ class CompileApiService(CompileService):
            &dest=gs://arxiv-sync-test-01/api-test/junk.json'
         '''
 
-        # This tgz may be older than the files in the src dir, 
-        #   since submit 2.0 does not yet regenerate after file changes.
-        # We could:
-        #   - update tex2pdf-api to build from the src dir
-        #   - update tex2pdf-api to support rezip
-        #   - check file dates and rezip locally, maybe on user request
-        source_path = current_app.api.get_file_store().get_full_source_package_path(submission.submission_id)
+        # tex2pdf's preflight endpoint takes a ``source`` URL pointing at a
+        # tar.gz in the bucket and scans it for compiler/issue detection.
+        # We rebuild the persisted ``<id>.tar.gz`` from the current ``src/``
+        # directory before each preflight call so tex2pdf sees the user's
+        # latest source. ``_common_file_change_execute`` deletes the same
+        # path on every file event, so the build here is "build if needed,
+        # not because we're scared" -- it's "always build the canonical
+        # path from current source." Per file event the deletion is cheap
+        # (one bucket call); per preflight click the build is one extraction
+        # of N source files, so cost is linear in workspace size, not in
+        # number of preceding file events.
+        file_store = current_app.api.get_file_store()
+        file_store.write_source_package(submission.submission_id)
 
-        preflight_path = current_app.api.get_file_store().get_full_preflight_package_path(submission.submission_id)
+        source_path = file_store.get_full_source_package_path(submission.submission_id)
+        preflight_path = file_store.get_full_preflight_package_path(submission.submission_id)
 
         query_params = {
             'source': source_path,

--- a/submit_ce/implementations/file_store/gs_file_store.py
+++ b/submit_ce/implementations/file_store/gs_file_store.py
@@ -326,6 +326,23 @@ class GsFileStore(SubmissionFileStore, FileStoreMixin):
             blob.delete()
 
     @override
+    def get_source_package(self, submission_id: str) -> FileObj:
+        """Retrieve the persisted ``<submission_id>.tar.gz`` source package."""
+        package_path = self._source_package_path(submission_id)
+        blob = self.bucket.blob(package_path)
+        if blob.exists():
+            # See get_preview: bucket.blob() returns a reference with empty
+            # metadata; reload so size/crc32c are populated for the route's
+            # Content-Length / ETag handling.
+            try:
+                blob.reload()
+            except Exception as exc:
+                logger.debug("source package reload failed for %s: %s",
+                             package_path, exc)
+            return blob
+        return FileDoesNotExist(package_path)
+
+    @override
     def get_preview_checksum(self, submission_id: str) -> str:
         """Get the checksum of the preview PDF for a submission."""
         return self._get_checksum(self._preview_path(submission_id))

--- a/submit_ce/implementations/file_store/gs_file_store.py
+++ b/submit_ce/implementations/file_store/gs_file_store.py
@@ -238,6 +238,94 @@ class GsFileStore(SubmissionFileStore, FileStoreMixin):
         return self.bucket.blob(self._source_package_path(submission_id)).exists()
 
     @override
+    def build_source_package(self, submission_id: str) -> bytes:
+        """Build a fresh .tar.gz from the current source files in the bucket.
+
+        Walks the submission's ``src/`` directory, fetches each blob,
+        and packs the contents into a gzipped tarball returned as
+        bytes. The persisted ``<submission_id>.tar.gz`` is NOT touched
+        by this method -- use :meth:`write_source_package` for that.
+
+        Files that are listed in the workspace but whose blobs cannot
+        be read are skipped with a warning rather than aborting the
+        build. Returns the gzipped tarball bytes; if the workspace is
+        empty, returns an empty (but valid) gzipped tar.
+        """
+        workspace = self.get_workspace(submission_id)
+        buf = io.BytesIO()
+        files_added = 0
+        files_skipped = 0
+        if workspace and workspace.files:
+            with tarfile.open(fileobj=buf, mode='w:gz') as tar:
+                for f in workspace.files:
+                    blob = self.get_source_file(
+                        submission_id=submission_id, path=f.path)
+                    if isinstance(blob, FileDoesNotExist):
+                        logger.warning(
+                            "build_source_package: workspace lists %s but "
+                            "blob is missing for submission %s; skipping",
+                            f.path, submission_id,
+                        )
+                        files_skipped += 1
+                        continue
+                    try:
+                        data = blob.download_as_bytes()
+                    except Exception as exc:
+                        logger.warning(
+                            "build_source_package: could not read %s for "
+                            "submission %s: %s; skipping",
+                            f.path, submission_id, exc,
+                        )
+                        files_skipped += 1
+                        continue
+
+                    info = tarfile.TarInfo(name=f.path)
+                    info.size = len(data)
+                    updated = getattr(blob, 'updated', None) or datetime.now()
+                    try:
+                        info.mtime = int(updated.timestamp())
+                    except (AttributeError, TypeError):
+                        info.mtime = int(datetime.now().timestamp())
+                    info.mode = 0o644
+                    tar.addfile(info, io.BytesIO(data))
+                    files_added += 1
+        else:
+            # No files: still emit a syntactically valid (empty) gzipped tar
+            with tarfile.open(fileobj=buf, mode='w:gz'):
+                pass
+        logger.info(
+            "build_source_package: built tarball for submission %s "
+            "(files_added=%d, files_skipped=%d, size_bytes=%d)",
+            submission_id, files_added, files_skipped, buf.tell(),
+        )
+        return buf.getvalue()
+
+    @override
+    def write_source_package(self, submission_id: str) -> None:
+        """Build the source package and upload it to the canonical path.
+
+        Overwrites any existing ``<submission_id>.tar.gz`` so callers
+        that resolve the source URL (e.g., the preflight API) see
+        current source rather than a stale snapshot from a previous
+        compile.
+        """
+        data = self.build_source_package(submission_id)
+        package_path = self._source_package_path(submission_id)
+        blob = self.bucket.blob(package_path)
+        blob.upload_from_file(io.BytesIO(data), content_type='application/gzip')
+        logger.info(
+            "write_source_package: wrote %s (size_bytes=%d)",
+            package_path, len(data),
+        )
+
+    @override
+    def delete_source_package(self, submission_id: str) -> None:
+        """Delete the persisted ``<submission_id>.tar.gz`` if it exists."""
+        blob = self.bucket.blob(self._source_package_path(submission_id))
+        if blob.exists():
+            blob.delete()
+
+    @override
     def get_preview_checksum(self, submission_id: str) -> str:
         """Get the checksum of the preview PDF for a submission."""
         return self._get_checksum(self._preview_path(submission_id))

--- a/submit_ce/implementations/file_store/mock_file_store.py
+++ b/submit_ce/implementations/file_store/mock_file_store.py
@@ -167,6 +167,12 @@ class MockFileStore(NullFileStore):
     def delete_source_package(self, submission_id: str) -> None:
         self._source_package.pop(submission_id, None)
 
+    def get_source_package(self, submission_id: str) -> FileObj:
+        data = self._source_package.get(submission_id)
+        if data is None:
+            return FileDoesNotExist(f"{submission_id}.tar.gz")
+        return _InMemoryFileObj(f"{submission_id}.tar.gz", data)
+
     def get_workspace(self, submission_id: str) -> Optional[Workspace]:
         files = self._source.get(submission_id, {})
         statuses = [_file_status_from_bytes(p, b) for p, b in files.items()]

--- a/submit_ce/implementations/file_store/mock_file_store.py
+++ b/submit_ce/implementations/file_store/mock_file_store.py
@@ -95,6 +95,7 @@ class MockFileStore(NullFileStore):
         self._preflight: Dict[str, bytes] = {}
         self._directives: Dict[str, bytes] = {}
         self._user_decisions: Dict[str, bytes] = {}
+        self._source_package: Dict[str, bytes] = {}
 
     # -------- source package / files --------
 
@@ -146,6 +147,25 @@ class MockFileStore(NullFileStore):
 
     def does_source_exist(self, submission_id: str) -> bool:
         return bool(self._source.get(submission_id))
+
+    def build_source_package(self, submission_id: str) -> bytes:
+        """Re-tar the in-memory source files into a gzipped tarball."""
+        files = self._source.get(submission_id, {})
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode='w:gz') as tar:
+            for path, data in files.items():
+                info = tarfile.TarInfo(name=path)
+                info.size = len(data)
+                info.mtime = int(datetime.now(timezone.utc).timestamp())
+                info.mode = 0o644
+                tar.addfile(info, io.BytesIO(data))
+        return buf.getvalue()
+
+    def write_source_package(self, submission_id: str) -> None:
+        self._source_package[submission_id] = self.build_source_package(submission_id)
+
+    def delete_source_package(self, submission_id: str) -> None:
+        self._source_package.pop(submission_id, None)
 
     def get_workspace(self, submission_id: str) -> Optional[Workspace]:
         files = self._source.get(submission_id, {})

--- a/submit_ce/ui/controllers/new/source_package.py
+++ b/submit_ce/ui/controllers/new/source_package.py
@@ -1,26 +1,34 @@
 """Controller for the Download Source Package endpoint.
 
-Builds a fresh ``.tar.gz`` on the fly from the current source files in
-the file store. Mirrors the pattern used by ``compile_at_gcp.py`` when it
-bundles source for the tex2pdf service, and the Submit 1.5
-``create_source_package`` Perl routine in ``Submit.pm``: in both systems
-the canonical source is the individual files under
-``<submission_id>/src/``, and the archive is built at request time
-rather than maintained as a separate artifact.
+Serves a freshly-built ``.tar.gz`` of the current source files. The
+actual tar-building lives on the file store
+(``SubmissionFileStore.build_source_package``) so the same builder is
+shared with other callers that need a current-source archive (notably
+``CompileApiService.start_preflight``, which rebuilds the persisted
+``<submission_id>.tar.gz`` before each preflight call so tex2pdf
+never receives a stale snapshot).
+
+Mirrors the pattern used by the Submit 1.5 ``create_source_package``
+Perl routine in ``Submit.pm``: the canonical source is the individual
+files under ``<submission_id>/src/``, and the archive is built at
+request time rather than maintained as a separate persistent artifact.
 
 Note: We deliberately do *not* serve the persisted ``<submission_id>.tar.gz``
-in the bucket: that copy is only refreshed by ``compile_at_gcp.py`` on a
-successful compile (see the ``shutil.copy2(temp_tar_path, new_tar_path)``
-block guarded by ``not preflight and status == 'success'``). It
-represents "the source that produced the last published PDF", not the
-user's current working source. For a Download Package button shown on
-the pre-compile Upload Files and Review Files steps, building from
-current source is the correct semantics.
+in the bucket directly: that copy is refreshed by
+``compile_at_gcp.py`` on a successful compile (see the
+``shutil.copy2(temp_tar_path, new_tar_path)`` block guarded by
+``not preflight and status == 'success'``) and by
+``start_preflight``. For a Download Package button shown on the
+pre-compile Upload Files and Review Files steps, building from current
+source via the file store is the correct semantics, and never reading
+the persisted ``<submission_id>.tar.gz`` is the simplest way to be
+sure we don't serve a stale snapshot.
 
-Note: A warning is logged when a file is not found in the Google Storage bucket.
-We may want to improve handling for such an error by alerting the user visually
-in the UI and systematically detecting and alerting on such an error. This may
-indicate inconsistent access to files in the Google Storage bucket.
+Note: A warning is logged inside the file store when a file is listed
+in the workspace but cannot be read back from the bucket. We may want
+to improve handling for such an error by alerting the user visually
+in the UI and systematically detecting such drift; it may indicate
+inconsistent bucket access.
 
 Linked from the sidebar of the Upload Files and Review Files pages.
 """
@@ -29,7 +37,6 @@ from __future__ import annotations
 
 import io
 import logging
-import tarfile
 from datetime import datetime, timezone
 from http import HTTPStatus as status
 from typing import Any, Dict, Tuple
@@ -39,82 +46,10 @@ from flask import current_app
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import NotFound
 
-from arxiv.files import FileDoesNotExist
 from submit_ce.ui.backend import get_submission
 
 
 logger = logging.getLogger(__name__)
-
-
-def _build_source_tarball(submission_id: str) -> bytes:
-    """Build a fresh .tar.gz from the current source files in the bucket.
-
-    Returns the gzipped tarball bytes. Files that are listed in the
-    workspace but no longer exist in the bucket (which would indicate
-    file-store drift) are skipped with a warning rather than aborting
-    the build.
-
-    Raises
-    ------
-    werkzeug.exceptions.NotFound
-        If the workspace has no source files (so there's nothing to
-        package).
-    """
-    file_store = current_app.api.get_file_store()
-    workspace = file_store.get_workspace(submission_id=submission_id)
-    if not workspace or not workspace.files:
-        raise NotFound(
-            "No source files are attached to this submission yet. "
-            "Upload files on the Upload Files step before downloading "
-            "a source package."
-        )
-
-    buf = io.BytesIO()
-    files_added = 0
-    files_skipped = 0
-    with tarfile.open(fileobj=buf, mode='w:gz') as tar:
-        for f in workspace.files:
-            blob = file_store.get_source_file(
-                submission_id=submission_id, path=f.path)
-            if isinstance(blob, FileDoesNotExist):
-                logger.warning(
-                    "source_package: workspace lists %s but blob is missing "
-                    "for submission %s; skipping",
-                    f.path, submission_id,
-                )
-                files_skipped += 1
-                continue
-            try:
-                data = blob.download_as_bytes()
-            except Exception as exc:
-                logger.warning(
-                    "source_package: could not read %s for submission %s: "
-                    "%s; skipping",
-                    f.path, submission_id, exc,
-                )
-                files_skipped += 1
-                continue
-
-            info = tarfile.TarInfo(name=f.path)
-            info.size = len(data)
-            # Use the blob's updated time if available; fall back to now.
-            updated = getattr(blob, 'updated', None) or datetime.now(timezone.utc)
-            try:
-                info.mtime = int(updated.timestamp())
-            except (AttributeError, TypeError):
-                info.mtime = int(datetime.now(timezone.utc).timestamp())
-            info.mode = 0o644
-            tar.addfile(info, io.BytesIO(data))
-            files_added += 1
-
-    logger.info(
-        "source_package: built tarball for submission %s "
-        "(files_added=%d, files_skipped=%d, size_bytes=%d)",
-        submission_id, files_added, files_skipped, buf.tell(),
-    )
-
-    buf.seek(0)
-    return buf.getvalue()
 
 
 def download_source_package(
@@ -133,7 +68,16 @@ def download_source_package(
     # already enforced by the route's @scoped decorator.
     submission, _ = get_submission(submission_id)
 
-    tar_bytes = _build_source_tarball(submission_id)
+    file_store = current_app.api.get_file_store()
+    workspace = file_store.get_workspace(submission_id=submission_id)
+    if not workspace or not workspace.files:
+        raise NotFound(
+            "No source files are attached to this submission yet. "
+            "Upload files on the Upload Files step before downloading "
+            "a source package."
+        )
+
+    tar_bytes = file_store.build_source_package(submission_id)
     stream = io.BytesIO(tar_bytes)
     stream.seek(0)
 

--- a/submit_ce/ui/controllers/new/source_package.py
+++ b/submit_ce/ui/controllers/new/source_package.py
@@ -42,11 +42,15 @@ from http import HTTPStatus as status
 from typing import Any, Dict, Tuple
 
 from arxiv.auth.domain import Session
+from arxiv.files import FileDoesNotExist
 from flask import current_app
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import NotFound
 
+from submit_ce.domain.event.process import BuildSourcePackage
 from submit_ce.ui.backend import get_submission
+
+from ...auth import user_and_client_from_session
 
 
 logger = logging.getLogger(__name__)
@@ -77,8 +81,28 @@ def download_source_package(
             "a source package."
         )
 
-    tar_bytes = file_store.build_source_package(submission_id)
-    stream = io.BytesIO(tar_bytes)
+    # Build the archive inside the submission's critical section. Dispatching
+    # BuildSourcePackage makes SubmitApi.save hold the submission row lock
+    # while write_source_package assembles the tar, so a concurrent upload or
+    # delete cannot change the file set mid-build (bdc34's review point on
+    # PR #76). We then stream the archive that was just persisted under the
+    # lock, rather than calling the unlocked build_source_package directly.
+    submitter, client = user_and_client_from_session(session)
+    current_app.api.save(
+        BuildSourcePackage(creator=submitter, client=client),
+        submission_id=submission_id,
+    )
+    package = file_store.get_source_package(submission_id)
+    if isinstance(package, FileDoesNotExist):
+        logger.error(
+            "source_package: package missing after BuildSourcePackage for %s",
+            submission_id,
+        )
+        raise NotFound(
+            "The source package could not be built. Please try again; if the "
+            "problem persists, contact arXiv support."
+        )
+    stream = io.BytesIO(package.download_as_bytes())
     stream.seek(0)
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")

--- a/submit_ce/ui/controllers/new/tests/test_source_package.py
+++ b/submit_ce/ui/controllers/new/tests/test_source_package.py
@@ -1,0 +1,65 @@
+"""Tests for :mod:`submit_ce.ui.controllers.new.source_package`.
+
+Focus: the Download Source Package build must run inside the submission's
+critical section (bdc34's review point on PR #76). We verify that the
+controller dispatches a ``BuildSourcePackage`` event -- which builds the tar
+under SubmitApi.save's row lock -- and streams the archive that was persisted
+under that lock, rather than building outside any lock.
+"""
+
+from http import HTTPStatus as status
+
+from werkzeug.datastructures import MultiDict
+from flask import current_app
+
+from arxiv.files import FileDoesNotExist
+
+from submit_ce.domain.event.process import BuildSourcePackage
+from submit_ce.implementations.file_store.mock_file_store import MockFileStore
+from submit_ce.ui.controllers.new.source_package import download_source_package
+
+
+def test_download_builds_package_under_lock(
+        app, authorized_user, authorized_user_session, sub_primary):
+    """Downloading builds via BuildSourcePackage (under the lock) and streams
+    the archive persisted by that event."""
+    session, _ = authorized_user_session
+    with app.app_context():
+        sid = str(sub_primary.submission_id)
+
+        store = MockFileStore()
+        current_app.api.store = store
+        store._source[sid] = {"main.tex": b"\\documentclass{article}\n"}
+
+        stream, code, headers = download_source_package(
+            "GET", MultiDict(), session, sid)
+
+        assert code == status.OK
+        assert headers["Content-Type"] == "application/gzip"
+        # Valid gzip magic bytes.
+        data = stream.read()
+        assert data[:2] == b"\x1f\x8b"
+
+        # The archive was persisted under the lock and is readable back.
+        assert not isinstance(store.get_source_package(sid), FileDoesNotExist)
+
+        # The build went through SubmitApi.save (the critical section): a
+        # BuildSourcePackage event is now in the submission history. Reload
+        # via get_with_history to bypass the per-request `g` cache.
+        _, events = current_app.api.get_with_history(sid)
+        assert any(isinstance(e, BuildSourcePackage) for e in events)
+
+
+def test_download_no_files_returns_not_found(
+        app, authorized_user, authorized_user_session, sub_primary):
+    """With no uploaded source files, the download 404s before building."""
+    from werkzeug.exceptions import NotFound
+    import pytest
+
+    session, _ = authorized_user_session
+    with app.app_context():
+        sid = str(sub_primary.submission_id)
+        current_app.api.store = MockFileStore()  # empty workspace
+
+        with pytest.raises(NotFound):
+            download_source_package("GET", MultiDict(), session, sid)


### PR DESCRIPTION
I detected this bug when I drastically changed the set of files, replacing several TeX files with a single PDF, and ended up with the previous set of TeX files at the Review Files page. This was caused by our lack of updating the gzipped tar and subsequently feeding this to the preflight request. This PR ensured that the gzipped tar is refreshed when needed. It also removed the gzipped tar when the submitter starts making changes to the set of files. The code that creates the tar has been relocated.