### PR TITLE
Bdc34/submission 174 mod email on submit

### DIFF
--- a/submit_ce/api/submit.py
+++ b/submit_ce/api/submit.py
@@ -65,7 +65,7 @@ from typing import Tuple, List, Optional
 
 from submit_ce.api.compile_service import CompileService
 from submit_ce.api.email_service import EmailService
-from submit_ce.domain import Submission, Event, License
+from submit_ce.domain import Submission, Event, License, Moderator
 from submit_ce.domain.config import SubmitConfig
 from submit_ce.domain.size_limits import SIZE_LIMIT_POLICY, SizeLimits
 from submit_ce.api.file_store import SubmissionFileStore
@@ -199,6 +199,30 @@ class SubmitApi(ABC):
         Returns
         -------
             `EmailService`
+        """
+        ...
+
+    @abstractmethod
+    def moderators_for_categories(self, categories: List[str]) \
+            -> List[Moderator]:
+        """Resolve a set of categories to the moderators to notify.
+
+        For each category this includes both category-level moderators and the
+        archive-level moderators of its archive, with moderators who have opted
+        out of web email excluded, de-duplicated by email address.
+
+        Used by `Events` with side effects (e.g. proposal notifications) to
+        determine email recipients. Intended to allow code with access to the
+        SubmitApi to also resolve category moderators.
+
+        Parameters
+        ----------
+        categories : List[str]
+            Category identifiers (e.g. ``["math.AG", "cs.AI"]``).
+
+        Returns
+        -------
+            List[`Moderator`]
         """
         ...
 

--- a/submit_ce/api/submit.py
+++ b/submit_ce/api/submit.py
@@ -203,13 +203,24 @@ class SubmitApi(ABC):
         ...
 
     @abstractmethod
-    def moderators_for_categories(self, categories: List[str]) \
-            -> List[Moderator]:
+    def moderators_for_categories(
+            self,
+            categories: List[str],
+            *,
+            exclude_no_web_email: bool = True,
+            exclude_no_email: bool = False,
+            exclude_no_reply_to: bool = False,
+    ) -> List[Moderator]:
         """Resolve a set of categories to the moderators to notify.
 
         For each category this includes both category-level moderators and the
-        archive-level moderators of its archive, with moderators who have opted
-        out of web email excluded, de-duplicated by email address.
+        archive-level moderators of its archive, de-duplicated by email address.
+
+        The ``exclude_*`` flags drop moderators who have set the corresponding
+        opt-out. The defaults match the proposal email (exclude ``no_web_email``
+        only); callers that compose To/Reply-To sets themselves (e.g. the
+        on-finalize moderator email) pass ``exclude_no_web_email=False`` to get
+        the full candidate set and filter on the returned `Moderator` flags.
 
         Used by `Events` with side effects (e.g. proposal notifications) to
         determine email recipients. Intended to allow code with access to the
@@ -219,6 +230,12 @@ class SubmitApi(ABC):
         ----------
         categories : List[str]
             Category identifiers (e.g. ``["math.AG", "cs.AI"]``).
+        exclude_no_web_email : bool
+            Drop moderators with the ``no_web_email`` opt-out set.
+        exclude_no_email : bool
+            Drop moderators with the ``no_email`` opt-out set.
+        exclude_no_reply_to : bool
+            Drop moderators with the ``no_reply_to`` opt-out set.
 
         Returns
         -------

--- a/submit_ce/domain/__init__.py
+++ b/submit_ce/domain/__init__.py
@@ -4,6 +4,7 @@ from .agent import (User, Client, PublicUser, StaffUser, System, ServiceAgent, a
 from .event import Event
 from .annotation import Comment
 from .meta import License, Classification
+from .moderator import Moderator
 from .preview import Preview
 from .proposal import Proposal, ProposalStatus
 from .submission import Submission, SubmissionMetadata, SubmissionType, Author, \
@@ -25,6 +26,7 @@ __all__ = [
     Comment,
     License,
     Classification,
+    Moderator,
     Preview,
     Proposal,
     ProposalStatus,

--- a/submit_ce/domain/__init__.py
+++ b/submit_ce/domain/__init__.py
@@ -1,5 +1,5 @@
 """Core data structures for the submission and moderation system."""
-from .agent import (User, Client, PublicUser, StaffUser, System, ServiceAgent, agent_factory,
+from .agent import (User, Client, PublicUser, StaffUser, System, agent_factory,
                     HttpClient, InternalClient, user_from_session)
 from .event import Event
 from .annotation import Comment
@@ -17,7 +17,6 @@ __all__ = [
     PublicUser,
     StaffUser,
     System,
-    ServiceAgent,
     agent_factory,
     HttpClient,
     InternalClient,

--- a/submit_ce/domain/__init__.py
+++ b/submit_ce/domain/__init__.py
@@ -5,6 +5,7 @@ from .event import Event
 from .annotation import Comment
 from .meta import License, Classification
 from .preview import Preview
+from .proposal import Proposal, ProposalStatus
 from .submission import Submission, SubmissionMetadata, SubmissionType, Author, \
     Hold, WithdrawalRequest, UserRequest, CrossListClassificationRequest
 from .uploads import Workspace
@@ -25,6 +26,8 @@ __all__ = [
     License,
     Classification,
     Preview,
+    Proposal,
+    ProposalStatus,
     Submission,
     SubmissionMetadata,
     SubmissionType,

--- a/submit_ce/domain/agent.py
+++ b/submit_ce/domain/agent.py
@@ -16,7 +16,7 @@ Problem: Class names are a ambiguous and overlap with arxiv-base class names
 from __future__ import annotations
 from typing import Union, Literal, Annotated, Optional
 
-__all__ = ("User", "Client", "ServiceAgent", "HttpClient", "InternalClient", "user_from_session",
+__all__ = ("User", "Client", "HttpClient", "InternalClient", "user_from_session",
            "PublicUser", "StaffUser", "System", "agent_factory")
 
 from arxiv.auth import auth
@@ -64,17 +64,6 @@ class StaffUser(BaseModel):
         return auth.scopes.PROXY_SUBMISSION in self.scopes
 
 
-
-class ServiceAgent(BaseModel):
-    """Represents a service agent."""
-    email: str = Field(min_length=3, max_length= 255)
-    agent_type: Literal["ServiceAgent"] = "ServiceAgent"
-
-    @property
-    def identifier(self):
-        return self.email
-
-
 class System(BaseModel):
     """Internal system not used with service agent credentials."""
     name: str = Field(min_length=3, max_length= 100)
@@ -85,7 +74,7 @@ class System(BaseModel):
         return self.name
 
 User = Annotated[
-    Union[PublicUser, StaffUser, System, ServiceAgent],
+    Union[PublicUser, StaffUser, System],
     Field(discriminator="agent_type")
 ]
 

--- a/submit_ce/domain/agent.py
+++ b/submit_ce/domain/agent.py
@@ -28,8 +28,8 @@ class PublicUser(BaseModel):
 
     Intentionally lacks name field, get that from user store."""
     user_id: str = Field(min_length=1, max_length=30)
-    name: str = Field(min_length=3, max_length=64) #length in arXiv_submissions
-    email: str = Field(min_length=3, max_length=64) #length in arXiv_submissions
+    name: str = Field(min_length=3, max_length=100)  # max of (length in arXiv_submissions, length tapir_user.first_name + last_name)
+    email: str = Field(min_length=3, max_length=255)  # max of (length arXiv_submissions, length in tapir_user)
     endorsements: list[str] = []
     scopes: list[str] = []
     agent_type: Literal["PublicUser"] = "PublicUser"
@@ -48,7 +48,7 @@ class StaffUser(BaseModel):
 
     Name can be recorded here."""
     user_id: str = Field(min_length=3, max_length= 30)
-    email: str = Field(min_length=3, max_length= 100)
+    email: str = Field(min_length=3, max_length= 255)
     name: str = Field(min_length=3, max_length= 100)
     username: str = Field(min_length=3, max_length= 100)
     endorsements: list[str] = []
@@ -67,7 +67,7 @@ class StaffUser(BaseModel):
 
 class ServiceAgent(BaseModel):
     """Represents a service agent."""
-    email: str = Field(min_length=3, max_length= 100)
+    email: str = Field(min_length=3, max_length= 255)
     agent_type: Literal["ServiceAgent"] = "ServiceAgent"
 
     @property

--- a/submit_ce/domain/config.py
+++ b/submit_ce/domain/config.py
@@ -32,6 +32,10 @@ class SubmitConfig(BaseModel):
     url_for_user_dashboard: str = "https://arxiv.org/user/"
     """Absolute URL of the user submission dashboard."""
 
+    url_for_moderator_review: str = "https://check.arxiv.org/submit/"
+    """Base URL of the moderator review page; the submission id is appended.
+    Real value read from ``Settings.URL_FOR_MODERATOR_REVIEW``."""
+
     mod_reply_to_email: str = "mod_reply_to_email@arxiv.example.com"
     """Moderation admin address; included in ``Reply-To`` on moderator emails.
     Real value read from ``Settings.MOD_REPLY_TO_EMAIL``."""
@@ -70,4 +74,7 @@ class SubmitConfig(BaseModel):
                    archival_email=config.get("ARCHIVAL_EMAIL",
                                                  defaults.archival_email),
                    url_for_user_dashboard=dashboard,
+                   url_for_moderator_review=config.get(
+                       "URL_FOR_MODERATOR_REVIEW",
+                       defaults.url_for_moderator_review),
                    )

--- a/submit_ce/domain/config.py
+++ b/submit_ce/domain/config.py
@@ -2,9 +2,11 @@
 
 `SubmitConfig` is a small, immutable bundle of the config values the *domain*
 layer needs (for example, when an event composes an email). It deliberately
-exposes only domain-relevant values, not the full application `Settings` (which
-also carries implementation details like DB URIs and SMTP credentials). An
-implementation builds one from its own settings and returns it via
+exposes only domain-relevant values, not the full application `Settings`. This
+is to avoid unwanted exposure in the api of implementation details like DB URIs
+and SMTP credentials.
+
+An implementation builds one from its own settings and returns it via
 `SubmitApi.get_config()`.
 """
 from typing import Union
@@ -18,15 +20,26 @@ class SubmitConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    email_reply_to: str = "www-admin@arxiv.org"
-    """``Reply-To`` address for normal submission confirmation emails."""
+    email_reply_to: str = "email_reply_to@arxiv.example.com"
+    """``Reply-To`` address for normal submission confirmation emails.
+    Real value read from ``Settings.EMAIL_REPLY_TO``."""
 
-    email_auto_hold_reply_to: str = "mod-lib@arxiv.org"
+    email_auto_hold_reply_to: str = "email_auto_hold_reply_to@arxiv.example.com"
     """``Reply-To`` address for auto-hold confirmation emails; replies go to
-    the moderation team rather than the general admin address."""
+    the moderation team rather than the general admin address.
+    Real value read from ``Settings.EMAIL_AUTO_HOLD_REPLY_TO``."""
 
     url_for_user_dashboard: str = "https://arxiv.org/user/"
     """Absolute URL of the user submission dashboard."""
+
+    mod_reply_to_email: str = "mod_reply_to_email@arxiv.example.com"
+    """Moderation admin address; included in ``Reply-To`` on moderator emails.
+    Real value read from ``Settings.MOD_REPLY_TO_EMAIL``."""
+
+    archival_email: str = "archival_email@arxiv.example.com"
+    """Internal admin address; ``Bcc``'d on moderator emails (and the ``To``
+    fallback when a category has no moderators).
+    Real value read from ``Settings.ARCHIVAL_EMAIL``."""
 
     @classmethod
     def from_config(cls, config: Union[dict, BaseSettings]) -> "SubmitConfig":
@@ -37,9 +50,6 @@ class SubmitConfig(BaseModel):
             config = config.model_dump()
 
         defaults = cls()
-        email_reply_to = config.get("EMAIL_REPLY_TO", defaults.email_reply_to)
-        email_auto_hold_reply_to = config.get(
-            "EMAIL_AUTO_HOLD_REPLY_TO", defaults.email_auto_hold_reply_to)
 
         dashboard = config.get("url_for_user_dashboard")
         if dashboard is None:
@@ -52,6 +62,12 @@ class SubmitConfig(BaseModel):
             else:
                 dashboard = defaults.url_for_user_dashboard
 
-        return cls(email_reply_to=email_reply_to,
-                   email_auto_hold_reply_to=email_auto_hold_reply_to,
-                   url_for_user_dashboard=dashboard)
+        return cls(email_reply_to=config.get("EMAIL_REPLY_TO", defaults.email_reply_to),
+                   email_auto_hold_reply_to=config.get("EMAIL_AUTO_HOLD_REPLY_TO",
+                                                       defaults.email_auto_hold_reply_to),
+                   mod_reply_to_email=config.get("MOD_REPLY_TO_EMAIL",
+                                              defaults.mod_reply_to_email),
+                   archival_email=config.get("ARCHIVAL_EMAIL",
+                                                 defaults.archival_email),
+                   url_for_user_dashboard=dashboard,
+                   )

--- a/submit_ce/domain/event/__init__.py
+++ b/submit_ce/domain/event/__init__.py
@@ -63,6 +63,7 @@ from . import validators
 from .base import Event
 from .base import event_factory as make_event
 from .email import EmailSubmitterFinalizeMsg
+from .email_mods import EmailProposalModeratorsMsg
 from .file import UploadFiles, RemoveFiles, RemoveAllFiles
 from .flag import AddMetadataFlag, AddUserFlag, AddContentFlag, RemoveFlag, \
     AddHold, RemoveHold
@@ -398,6 +399,8 @@ class ProposeClassification(Event):
     NAME = "propose classification"
     NAMED = "classification proposed"
 
+    CONSEQUENCE_TYPES = frozenset({EmailProposalModeratorsMsg})
+
     category: Optional[ActiveCategory] = None
     is_primary: bool = False
     comment: Optional[str] = None
@@ -432,6 +435,28 @@ class ProposeClassification(Event):
         )
         submission.proposals[self.event_id] = proposal
         return submission
+
+    def consequences(self, submission: Submission) -> List[Event]:
+        """Email the moderators of the affected categories about the proposal.
+
+        System/classifier proposals are silent (matches legacy: auto-proposals
+        are logged with ``notify=0`` and send no email). For a primary proposal
+        the affected categories also include the submission's current primary
+        and any other unresolved primary proposals, so their moderators are
+        notified too.
+        """
+        if isinstance(self.creator, System):
+            return []
+
+        sid = submission.submission_id
+        return [EmailProposalModeratorsMsg(
+            creator=System(name=__name__),
+            submission_id=str(sid) if sid is not None else None,
+            proposed_category=self.category,
+            is_primary=self.is_primary,
+            comment=self.comment,
+            proposer_name=getattr(self.creator, "name", None),
+        )]
 
 
 class SetLicense(Event):

--- a/submit_ce/domain/event/__init__.py
+++ b/submit_ce/domain/event/__init__.py
@@ -62,7 +62,8 @@ from pytz import UTC
 from . import validators
 from .base import Event
 from .base import event_factory as make_event
-from .email import EmailSubmitterFinalizeMsg
+from .email import EmailSubmitterFinalizeMsg, _is_auto_hold
+from .email_mod_finalize import EmailModeratorsFinalizeMsg
 from .email_mods import EmailProposalModeratorsMsg
 from .file import UploadFiles, RemoveFiles, RemoveAllFiles
 from .flag import AddMetadataFlag, AddUserFlag, AddContentFlag, RemoveFlag, \
@@ -75,7 +76,7 @@ from ..annotation import Feature, ClassifierResults, \
 from ..preview import Preview
 from ..proposal import Proposal, ProposalStatus
 from ..submission import Submission, Author, \
-    Classification, License, Hold
+    Classification, License, Hold, SubmissionType
 from ..uploads import SourceFormat
 from ..exceptions import InvalidEvent
 
@@ -1055,7 +1056,15 @@ class FinalizeSubmission(Event):
     ]
     REQUIRED_METADATA: ClassVar[str] = ['title', 'abstract', 'authors_display']
 
-    CONSEQUENCE_TYPES = frozenset({AddHold, EmailSubmitterFinalizeMsg})
+    CONSEQUENCE_TYPES = frozenset({AddHold, EmailSubmitterFinalizeMsg,
+                                   EmailModeratorsFinalizeMsg})
+
+    MOD_EMAIL_TYPES: ClassVar[frozenset] = frozenset({
+        SubmissionType.NEW, SubmissionType.REPLACEMENT,
+        SubmissionType.WITHDRAWAL, SubmissionType.CROSS_LIST})
+    """Submission types that send a moderator email on finalize (legacy: types
+    with a ``mod_template``). ``jref`` is excluded, as are auto-held
+    submissions; see :meth:`consequences`."""
 
     def validate_pre_lock(self, submission: Submission) -> None:
         """Ensure that all required data/steps are complete."""
@@ -1079,19 +1088,29 @@ class FinalizeSubmission(Event):
            :attr:`Submission.is_on_hold` report true; there is no separate hold
            status in this model. Skipped if a waiver already exists.
         2. Send the submitter the on-submit confirmation email.
+        3. Notify the affected categories' moderators, but only for submission
+           types (`new`/`rep`/`wdr`/`cross`) and only when the submission is not
+           auto-held. An auto-held submission (e.g. oversize)
+           is not sent to moderators until the problems are fixed.
         """
         events: List[Event] = []
+        sid = submission.submission_id
+        sid_str = str(sid) if sid is not None else None
         if submission.is_oversize \
                 and not submission.has_waiver_for(Hold.Type.SOURCE_OVERSIZE):
             events.append(AddHold(creator=System(name=__name__),
                                   submission_id=submission.submission_id,
                                   hold_type=Hold.Type.SOURCE_OVERSIZE,
                                   hold_reason="source is oversize"))
-        sid = submission.submission_id
         events.append(EmailSubmitterFinalizeMsg(
             creator=System(name=__name__),
             email_to=self.creator,
-            submission_id=str(sid) if sid is not None else None))
+            submission_id=sid_str))
+        if submission.submission_type in self.MOD_EMAIL_TYPES \
+                and not _is_auto_hold(submission):
+            events.append(EmailModeratorsFinalizeMsg(
+                creator=System(name=__name__),
+                submission_id=sid_str))
         return events
 
     def _required_fields_are_complete(self, submission: Submission) -> None:

--- a/submit_ce/domain/event/__init__.py
+++ b/submit_ce/domain/event/__init__.py
@@ -392,9 +392,10 @@ class ProposeClassification(Event):
 
     A proposal is a *suggestion* to change the submission's classification, made
     either automatically (by the classifier) or manually (by a moderator). It
-    does not itself change the submission's categories; it records a
-    :class:`.domain.proposal.Proposal` awaiting a response. Maps onto the classic
-    ``arXiv_submission_category_proposal`` table.
+    does not change the submission's categories; it records a
+    :class:`.domain.proposal.Proposal` awaiting a response.
+
+    Maps onto the classic ``arXiv_submission_category_proposal`` table.
     """
 
     NAME = "propose classification"
@@ -441,10 +442,7 @@ class ProposeClassification(Event):
         """Email the moderators of the affected categories about the proposal.
 
         System/classifier proposals are silent (matches legacy: auto-proposals
-        are logged with ``notify=0`` and send no email). For a primary proposal
-        the affected categories also include the submission's current primary
-        and any other unresolved primary proposals, so their moderators are
-        notified too.
+        are logged with ``notify=0`` and send no email).
         """
         if isinstance(self.creator, System):
             return []

--- a/submit_ce/domain/event/__init__.py
+++ b/submit_ce/domain/event/__init__.py
@@ -72,6 +72,7 @@ from ..agent import System
 from ..annotation import Feature, ClassifierResults, \
     ClassifierResult
 from ..preview import Preview
+from ..proposal import Proposal, ProposalStatus
 from ..submission import Submission, Author, \
     Classification, License, Hold
 from ..uploads import SourceFormat
@@ -92,7 +93,8 @@ __all__ = [
     ClassifierResult,
     Preview,
     Submission, Author,
-    Classification, License
+    Classification, License,
+    Proposal, ProposalStatus,
 ]
 
 import logging
@@ -381,6 +383,55 @@ class RemoveSecondaryClassification(Event):
         """One cannot remove a secondary that is not actually set."""
         if self.category not in submission.secondary_categories:
             raise InvalidEvent(self, 'No such category on submission')
+
+
+class ProposeClassification(Event):
+    """Propose a primary or cross-list classification for a submission.
+
+    A proposal is a *suggestion* to change the submission's classification, made
+    either automatically (by the classifier) or manually (by a moderator). It
+    does not itself change the submission's categories; it records a
+    :class:`.domain.proposal.Proposal` awaiting a response. Maps onto the classic
+    ``arXiv_submission_category_proposal`` table.
+    """
+
+    NAME = "propose classification"
+    NAMED = "classification proposed"
+
+    category: Optional[ActiveCategory] = None
+    is_primary: bool = False
+    comment: Optional[str] = None
+
+    def validate_pre_lock(self, submission: Submission) -> None:
+        """Validate the proposed category."""
+        if self.category is None:
+            raise InvalidEvent(self, "Must have a category")
+        validators.must_be_an_active_category(self, self.category, submission)
+        self._no_duplicate_unresolved_proposal(submission)
+
+    def _no_duplicate_unresolved_proposal(self, submission: Submission) -> None:
+        """Reject a proposal that duplicates an existing unresolved one."""
+        for proposal in submission.proposals.values():
+            if proposal.category == self.category \
+                    and proposal.is_primary == self.is_primary \
+                    and proposal.is_unresolved:
+                raise InvalidEvent(
+                    self, f"{self.category} has already been proposed")
+
+    def project(self, submission: Submission) -> Submission:
+        """Record a :class:`.domain.proposal.Proposal` on the submission."""
+        assert self.category is not None
+        proposal = Proposal(
+            proposal_id=self.event_id,
+            category=self.category,
+            is_primary=self.is_primary,
+            creator=self.creator,
+            created=self.created,
+            comment=self.comment,
+            status=ProposalStatus.UNRESOLVED,
+        )
+        submission.proposals[self.event_id] = proposal
+        return submission
 
 
 class SetLicense(Event):

--- a/submit_ce/domain/event/email.py
+++ b/submit_ce/domain/event/email.py
@@ -5,7 +5,7 @@ TODO ``Re:`` resubmit threading
 from typing import Optional, TYPE_CHECKING
 from urllib.parse import urlparse
 
-from ..agent import ServiceAgent, System, User
+from ..agent import System, User
 from ..config import SubmitConfig
 from ..submission import Submission, SubmissionType
 from .base import EventWithSideEffect
@@ -341,8 +341,6 @@ def submitter_recipient(user: User) -> tuple[str, str]:
     match user:
         case System():
             return "", ""
-        case ServiceAgent():
-            return user.email, user.email
         case _:
             return user.name, user.email
 

--- a/submit_ce/domain/event/email_mod_finalize.py
+++ b/submit_ce/domain/event/email_mod_finalize.py
@@ -1,0 +1,201 @@
+"""Event that emails category moderators when a submission is finalized.
+
+Emitted as a consequence of :class:`.FinalizeSubmission` for the submission
+types (``new``/``rep``/``wdr``/ ``cross``) and that are not auto-held. The type
+gating itself lives in :meth:`.FinalizeSubmission.consequences`.
+
+Recipient/header composition:
+
+- Candidate moderators = union over the submission's categories and its
+  unresolved proposed categories of category-level and archive-level moderators.
+  Unlike the proposal email, ``no_web_email`` moderators are NOT excluded here,
+  so the full candidate set is fetched and filtered per header in Python.
+- ``To``: candidates without ``no_email``; falls back to ``archival_email`` when
+  empty.
+- ``Reply-To``: ``mod_reply_to_email`` followed by candidates without
+  ``no_reply_to``.
+- ``Bcc``: ``archival_email``, omitted when ``To`` fell back to it.
+
+Sending is non-fatal: any failure is recorded on :attr:`error` and never raised,
+so it cannot abort the finalize transaction.
+
+"""
+
+from typing import List, Optional, TYPE_CHECKING
+from urllib.parse import urlparse
+
+from ..submission import Submission, SubmissionType
+from .base import EventWithSideEffect
+from .email import render_submission_summary
+
+if TYPE_CHECKING:
+    from submit_ce.api.submit import SubmitApi
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def _categories(submission: Submission) -> List[str]:
+    """The submission's primary + secondary categories, in order."""
+    cats: List[str] = []
+    if submission.primary_classification:
+        cats.append(submission.primary_classification.category)
+    cats.extend(submission.secondary_categories)
+    return cats
+
+
+class EmailModeratorsFinalizeMsg(EventWithSideEffect):
+    """Notify the moderators of the affected categories that a submission was finalized."""
+
+    NAME = "email moderators on finalize"
+    NAMED = "finalize moderators emailed"
+
+    error: Optional[str] = None
+    """Set if the email could not be sent; the finalize still succeeds."""
+
+    msg_id: Optional[str] = None
+
+    def validate_pre_lock(self, submission: Submission) -> None:
+        """No precondition; this is a consequence of a validated finalize."""
+        pass
+
+    def execute(self, api: 'SubmitApi', submission: Submission) -> None:
+        """Resolve moderators, compose, and send. Never raises."""
+        try:
+            service = api.get_email_service()
+            if service is None or not service.is_available():
+                self.error = ("email not configured or unavailable, no moderator"
+                              " notification sent")
+                logger.warning("Submission %s: %s", submission.submission_id,
+                               self.error)
+                return
+
+            config = api.get_config()
+            categories_to_email = self.categories_to_email(submission)
+            # Fetch the full candidate set (no_web_email NOT excluded, per spec)
+            # and compute the To / Reply-To sets ourselves from the opt-out flags.
+            mods = api.moderators_for_categories(
+                categories_to_email, exclude_no_web_email=False)
+
+            to_mods = [m.email for m in mods if not m.no_email]
+            reply_to_mods = [m.email for m in mods if not m.no_reply_to]
+
+            if to_mods:
+                to = to_mods
+                bcc: Optional[List[str]] = [config.archival_email]
+            else:
+                # No eligible moderators: fall back to the archival admin and
+                # drop the (now redundant) Bcc.
+                to = [config.archival_email]
+                bcc = None
+                logger.info("Submission %s: no moderators for %s; finalize "
+                            "notification sent to %s", submission.submission_id,
+                            categories_to_email, config.archival_email)
+
+            reply_to = ",".join([config.mod_reply_to_email] + reply_to_mods)
+
+            subject, body = self._build_subject_and_body(submission, config)
+            message_id, references = self._threading(submission, config)
+
+            msg_id, problems = service.send_email(
+                to=to,
+                subject=subject,
+                body=body,
+                reply_to=reply_to,
+                bcc=bcc,
+                message_id=message_id,
+                references=references,
+            )
+            self.msg_id = msg_id
+            self.error = problems or None
+        except Exception as e:  # noqa: BLE001 - email send must never abort finalize
+            self.error = f"failed to send moderator finalize email: {e}"
+            logger.warning("Submission %s: %s", submission.submission_id,
+                           self.error)
+
+    def categories_to_email(self, submission: Submission) -> List[str]:
+        """Categories whose moderators should be notified.
+
+        Union of the submission's categories and the categories of its
+        unresolved proposals. Legacy uses the *new* (unpublished) categories;
+        the model has no per-category published flag yet, so primary+secondary
+        stands in as a safe superset.
+
+        TODO: narrow to genuinely-new categories once published-category tracking exists.
+        Currently legacy has no db or domain info about published categories.
+        """
+        cats = set(_categories(submission))
+        for proposal in submission.proposals.values():
+            if proposal.is_unresolved:
+                cats.add(proposal.category)
+        return sorted(c for c in cats if c)
+
+    def _threading(self, submission: Submission, config) -> tuple[str, str]:
+        """Stable ``(message_id, references)`` so resubmits thread together.
+
+        Matches legacy ``<submit.<submission_id>@<site>>``.
+        """
+        site = urlparse(config.url_for_user_dashboard).hostname or "arxiv.org"
+        message_id = f"<submit.{submission.submission_id}@{site}>"
+        return message_id, message_id
+
+    def _build_subject_and_body(self, submission: Submission, config) \
+            -> tuple[str, str]:
+        """Compose the per-type ``(subject, body)`` (spec §5).
+
+        Dispatches on :attr:`.Submission.submission_type`. Variables the model
+        does not yet expose (``submitter_warnings``, ``near_duplicates``, the
+        real ``classifier_moderator_abstract``, genuinely "newly added"
+        categories) are left as TODO placeholders, matching the precedent in
+        ``email.py``. ``render_submission_summary`` stands in for the legacy
+        ``classifier_moderator_abstract`` / ``write_to_string`` blocks.
+        """
+        sid = submission.submission_id
+        arxiv_id = submission.arxiv_id or ""
+        name = getattr(submission.creator, "name", "") or ""
+        email = getattr(submission.creator, "email", "") or ""
+        categories_str = " ".join(_categories(submission))
+        review_url = f"{config.url_for_moderator_review}{sid}"
+        summary = render_submission_summary(submission)
+
+        # TODO: prefix "Re:" on a resubmit once that state is tracked.
+        # TODO: render submitter_warnings / near_duplicates once those exist.
+
+        sub_type = submission.submission_type or SubmissionType.NEW
+
+        if sub_type == SubmissionType.REPLACEMENT:
+            subject = f"arXiv replacement {sid} for {arxiv_id} by {name}"
+            lines = []
+            # TODO: only the genuinely added categories belong here.
+            if categories_str:
+                lines.append(f"Categories added: {categories_str}")
+            lines += [f"View the replacement: {review_url}", "", summary]
+            return subject, "\n".join(lines) + "\n"
+
+        if sub_type == SubmissionType.WITHDRAWAL:
+            subject = f"arXiv withdrawal {sid} for {arxiv_id} by {name}"
+            body = f"View the withdrawal: {review_url}\n\n{summary}\n"
+            return subject, body
+
+        if sub_type == SubmissionType.CROSS_LIST:
+            subject = (f"arXiv cross {sid} to {categories_str} for {arxiv_id} "
+                       f"by {name}")
+            body = (f"A crosslist has been added by submitter {name}, {email} "
+                    f"for {arxiv_id}.\n\n"
+                    f"View the submission: {review_url}\n\n{summary}\n")
+            return subject, body
+
+        # Default: SubmissionType.NEW
+        subject = f"arXiv submission {sid} to {categories_str} by {name}"
+        lines = []
+        primary_proposals = [p.category for p in submission.proposals.values()
+                             if p.is_primary and p.is_unresolved]
+        if primary_proposals:
+            lines.append("System-proposed primaries: "
+                         + " ".join(sorted(primary_proposals)))
+        lines += [f"View the submission: {review_url}", "", summary]
+        return subject, "\n".join(lines) + "\n"
+
+    def project(self, submission: Submission) -> Submission:
+        """No state change; this event only sends mail."""
+        return submission

--- a/submit_ce/domain/event/email_mods.py
+++ b/submit_ce/domain/event/email_mods.py
@@ -3,8 +3,10 @@
 Emitted as a consequence of :class:`.ProposeClassification` for moderator-made
 proposals (system/classifier proposals are silent, matching legacy). It resolves
 which moderators to notify via :meth:`.SubmitApi.moderators_for_categories` and
-sends the notification. Sending is non-fatal: any failure is recorded on
-:attr:`error` and never raised, so it cannot abort the transaction.
+sends the notification.
+
+Sending is non-fatal: any failure is recorded on :attr:`error` and never raised,
+so it cannot abort the transaction.
 
 Recipient/header composition mirrors the legacy proposal email
 (``arXiv::Submit::Email::OnAdminLog``):
@@ -13,6 +15,7 @@ Recipient/header composition mirrors the legacy proposal email
 - ``Reply-To``: ``mod-admin`` followed by the moderator emails.
 - ``Bcc``: ``local-admin`` (omitted when falling back to a ``local-admin`` ``To``).
 - The submitter is never a recipient; their name appears only in the subject.
+
 """
 
 from typing import List, Optional, TYPE_CHECKING
@@ -96,15 +99,22 @@ class EmailProposalModeratorsMsg(EventWithSideEffect):
                            self.error)
 
     def categories_to_email(self, submission: Submission) -> list[str]:
+        """
+        For a primary proposal the affected categories also include the
+        submission's current primary and any other unresolved primary proposals,
+        so their moderators are notified too.
+
+        For secondary, just the mods of the proposed secondary are emailed
+        """
         cats = {self.proposed_category}
         if self.is_primary:
             if submission.primary_classification:
                 cats.add(submission.primary_classification.category)
-        for proposal in submission.proposals.values():
-            if proposal.is_primary and proposal.is_unresolved:
-                cats.add(proposal.category)
+            for proposal in submission.proposals.values():
+                if proposal.is_primary and proposal.is_unresolved:
+                    cats.add(proposal.category)
 
-        return sorted(c for c in cats if c)
+        return sorted(set(c for c in cats if c))
 
     def _build_subject_and_body(self, submission: Submission) -> tuple[str, str]:
         """Compose the proposal notification ``(subject, body)``."""

--- a/submit_ce/domain/event/email_mods.py
+++ b/submit_ce/domain/event/email_mods.py
@@ -1,0 +1,142 @@
+"""Event that emails category moderators when a proposal is made.
+
+Emitted as a consequence of :class:`.ProposeClassification` for moderator-made
+proposals (system/classifier proposals are silent, matching legacy). It resolves
+which moderators to notify via :meth:`.SubmitApi.moderators_for_categories` and
+sends the notification. Sending is non-fatal: any failure is recorded on
+:attr:`error` and never raised, so it cannot abort the transaction.
+
+Recipient/header composition mirrors the legacy proposal email
+(``arXiv::Submit::Email::OnAdminLog``):
+
+- ``To``: the resolved moderator emails, or ``local-admin`` if there are none.
+- ``Reply-To``: ``mod-admin`` followed by the moderator emails.
+- ``Bcc``: ``local-admin`` (omitted when falling back to a ``local-admin`` ``To``).
+- The submitter is never a recipient; their name appears only in the subject.
+"""
+
+from typing import List, Optional, TYPE_CHECKING
+
+from pydantic import Field
+
+from ..submission import Submission
+from .base import EventWithSideEffect
+
+if TYPE_CHECKING:
+    from submit_ce.api.submit import SubmitApi
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class EmailProposalModeratorsMsg(EventWithSideEffect):
+    """Notify the moderators of the affected categories that a proposal was made."""
+
+    NAME = "email moderators on proposal"
+    NAMED = "proposal moderators emailed"
+
+    proposed_category: Optional[str] = None
+    is_primary: bool = False
+    comment: Optional[str] = None
+    proposer_name: Optional[str] = None
+    """Display name of the moderator who made the proposal."""
+
+    error: Optional[str] = None
+    """Set if the email could not be sent; the proposal still succeeds."""
+
+    msg_id: Optional[str] = None
+
+    def validate_pre_lock(self, submission: Submission) -> None:
+        """No precondition; this is a consequence of a validated proposal."""
+        pass
+
+    def execute(self, api: 'SubmitApi', submission: Submission) -> None:
+        """Resolve moderators, compose, and send. Never raises."""
+        try:
+            service = api.get_email_service()
+            if service is None or not service.is_available():
+                self.error = ("email not configured or unavailable, no moderator"
+                              " notification sent")
+                logger.warning("Submission %s: %s", submission.submission_id,
+                               self.error)
+                return
+
+            categories_to_email=self.categories_to_email(submission)
+            emails = [mod.email for mod in
+                      api.moderators_for_categories(categories_to_email)]
+
+            config = api.get_config()
+            subject, body = self._build_subject_and_body(submission)
+
+            if emails:
+                to = emails
+                reply_to = ",".join([config.mod_reply_to_email] + emails)
+                bcc: Optional[List[str]] = [config.archival_email]
+            else:
+                # No moderators for these categories: fall back to local-admin.
+                to = [config.archival_email]
+                reply_to = config.mod_reply_to_email
+                bcc = None
+                logger.info("Submission %s: no moderators for %s; proposal "
+                            "notification sent to %s", submission.submission_id,
+                            categories_to_email, config.archival_email)
+
+            msg_id, problems = service.send_email(
+                to=to,
+                subject=subject,
+                body=body,
+                reply_to=reply_to,
+                bcc=bcc,
+            )
+            self.msg_id = msg_id
+            self.error = problems or None
+        except Exception as e:  # noqa: BLE001 - email send must never abort the save
+            self.error = f"failed to send moderator proposal email: {e}"
+            logger.warning("Submission %s: %s", submission.submission_id,
+                           self.error)
+
+    def categories_to_email(self, submission: Submission) -> list[str]:
+        cats = {self.proposed_category}
+        if self.is_primary:
+            if submission.primary_classification:
+                cats.add(submission.primary_classification.category)
+        for proposal in submission.proposals.values():
+            if proposal.is_primary and proposal.is_unresolved:
+                cats.add(proposal.category)
+
+        return sorted(c for c in cats if c)
+
+    def _build_subject_and_body(self, submission: Submission) -> tuple[str, str]:
+        """Compose the proposal notification ``(subject, body)``."""
+        sid = submission.submission_id
+        categories = []
+        if submission.primary_classification:
+            categories.append(submission.primary_classification.category)
+        categories.extend(submission.secondary_categories)
+        categories_str = " ".join(categories)
+
+        submitter_name = getattr(submission.creator, "name", "") or ""
+        prefix = "Action Required: " if submission.is_on_hold else "Re: "
+        subject = (f"{prefix}arXiv submission {sid} to {categories_str} "
+                   f"by {submitter_name}")
+
+        type_str = "primary" if self.is_primary else "secondary"
+        proposer = self.proposer_name or "a moderator"
+        lines = [
+            f"A category proposal has been made on arXiv submission {sid}.",
+            "",
+            f"Proposed: {self.proposed_category} as {type_str}",
+        ]
+        if self.comment:
+            lines.append(f"Comment: {self.comment}")
+        lines += [
+            f"Proposed by: {proposer}",
+            "",
+            f"Current categories: {categories_str or '[no primary]'}",
+            f"Submitted by: {submitter_name}",
+        ]
+        return subject, "\n".join(lines) + "\n"
+
+    def project(self, submission: Submission) -> Submission:
+        """No state change; this event only sends mail."""
+        return submission

--- a/submit_ce/domain/event/tests/test_email_mod_finalize.py
+++ b/submit_ce/domain/event/tests/test_email_mod_finalize.py
@@ -1,0 +1,231 @@
+"""Unit tests for `EmailModeratorsFinalizeMsg` (the on-finalize moderator email).
+
+The event's `execute` side effect is exercised directly with hand-built
+submissions and a stub API, so no app, DB, or file store is needed. Sending must
+be non-fatal: a failure is recorded on `event.error`, never raised. The To /
+Reply-To sets are derived from the per-moderator opt-out flags; To falls back to
+the archival admin when no moderator is eligible.
+"""
+from datetime import datetime
+
+from pytz import UTC
+
+from submit_ce.domain import agent
+from submit_ce.domain.meta import Classification
+from submit_ce.domain.config import SubmitConfig
+from submit_ce.domain.moderator import Moderator
+from submit_ce.domain.proposal import Proposal, ProposalStatus
+from submit_ce.domain.event import EmailModeratorsFinalizeMsg
+from submit_ce.domain.submission import (
+    Submission, SubmissionMetadata, SubmissionType,
+)
+from submit_ce.implementations.email.email_in_memory import EmailInMemory
+
+
+def _submitter():
+    return agent.PublicUser(name="Sam Submitter", user_id="u1",
+                            email="submitter@example.org", endorsements=[])
+
+
+def _submission(submission_type=SubmissionType.NEW, arxiv_id=None, proposals=None):
+    u = _submitter()
+    return Submission(
+        submission_id="12345",
+        creator=u, owner=u, created=datetime.now(UTC),
+        primary_classification=Classification(category="astro-ph.GA"),
+        submission_type=submission_type,
+        arxiv_id=arxiv_id,
+        proposals=proposals or {},
+        metadata=SubmissionMetadata(title="A Fine Paper",
+                                    authors_display="Sam Submitter",
+                                    abstract="An abstract."))
+
+
+def _mods():
+    # Distinct opt-out flags so To and Reply-To diverge.
+    return [
+        Moderator(user_id="2", email="ag@example.org", archive="astro-ph",
+                  subject_class="GA", name="Alice Gauss"),
+        Moderator(user_id="3", email="bee@example.org", archive="astro-ph",
+                  subject_class="", name="Bee Admin", no_email=True),
+        Moderator(user_id="4", email="cee@example.org", archive="astro-ph",
+                  subject_class="GA", name="Cee Reply", no_reply_to=True),
+    ]
+
+
+def _event(**kwargs):
+    defaults = dict(
+        creator=agent.System(name="test"),
+        submission_id="12345",
+        created=datetime.now(UTC),
+    )
+    defaults.update(kwargs)
+    return EmailModeratorsFinalizeMsg(**defaults)
+
+
+class _Api:
+    """Stub exposing get_email_service, get_config, moderators_for_categories."""
+    def __init__(self, service, mods=None, config=None):
+        self._service = service
+        self._mods = mods if mods is not None else _mods()
+        self._config = config or SubmitConfig(
+            mod_reply_to_email="mod-admin-email@arxiv.example.org",
+            archival_email="local-admin-email@arxiv.example.org")
+        self.last_call = None
+
+    def get_email_service(self):
+        return self._service
+
+    def get_config(self):
+        return self._config
+
+    def moderators_for_categories(self, categories, **kwargs):
+        self.last_call = (list(categories), kwargs)
+        return list(self._mods)
+
+
+# --- execute(): header composition ---
+
+def test_to_excludes_no_email_reply_to_excludes_no_reply_to():
+    service = EmailInMemory()
+    api = _Api(service)
+    _event().execute(api, _submission())
+
+    sent = service.last
+    # To: drops the no_email moderator (bee).
+    assert sent.to == ["ag@example.org", "cee@example.org"]
+    # Reply-To: mod-admin first, then moderators minus the no_reply_to one (cee).
+    assert sent.reply_to == \
+        "mod-admin-email@arxiv.example.org,ag@example.org,bee@example.org"
+    assert sent.bcc == ["local-admin-email@arxiv.example.org"]
+
+
+def test_fetches_full_candidate_set_without_web_email_exclusion():
+    api = _Api(EmailInMemory())
+    _event().execute(api, _submission())
+    cats, kwargs = api.last_call
+    assert kwargs.get("exclude_no_web_email") is False
+
+
+def test_no_moderators_falls_back_to_local_admin():
+    service = EmailInMemory()
+    _event().execute(_Api(service, mods=[]), _submission())
+    sent = service.last
+    assert sent.to == ["local-admin-email@arxiv.example.org"]
+    assert sent.reply_to == "mod-admin-email@arxiv.example.org"
+    assert sent.bcc == []  # Bcc omitted on the fallback
+
+
+def test_all_no_email_moderators_falls_back():
+    mods = [Moderator(user_id="9", email="x@example.org", archive="astro-ph",
+                      subject_class="GA", no_email=True)]
+    service = EmailInMemory()
+    _event().execute(_Api(service, mods=mods), _submission())
+    sent = service.last
+    assert sent.to == ["local-admin-email@arxiv.example.org"]
+    # The no_email moderator is still eligible for Reply-To.
+    assert sent.reply_to == "mod-admin-email@arxiv.example.org,x@example.org"
+
+
+def test_submitter_is_never_a_recipient():
+    service = EmailInMemory()
+    _event().execute(_Api(service), _submission())
+    sent = service.last
+    recipients = sent.to + sent.bcc + [sent.reply_to]
+    assert all("submitter@example.org" not in r for r in recipients)
+
+
+def test_threading_message_id_is_stable():
+    service = EmailInMemory()
+    _event().execute(_Api(service), _submission())
+    sent = service.last
+    assert sent.message_id == "<submit.12345@arxiv.org>"
+    assert sent.references == sent.message_id
+
+
+# --- execute(): per-type subjects/bodies ---
+
+def test_new_subject_and_review_link():
+    service = EmailInMemory()
+    _event().execute(_Api(service), _submission())
+    sent = service.last
+    assert sent.subject == \
+        "arXiv submission 12345 to astro-ph.GA by Sam Submitter"
+    assert "View the submission: https://check.arxiv.org/submit/12345" in sent.body
+
+
+def test_new_lists_system_proposed_primaries():
+    proposals = {"p1": Proposal(proposal_id="p1", category="math.AG",
+                                is_primary=True, creator=agent.System(name="cls"),
+                                status=ProposalStatus.UNRESOLVED)}
+    service = EmailInMemory()
+    _event().execute(_Api(service), _submission(proposals=proposals))
+    assert "System-proposed primaries: math.AG" in service.last.body
+
+
+def test_replacement_subject():
+    service = EmailInMemory()
+    _event().execute(_Api(service),
+                     _submission(SubmissionType.REPLACEMENT, arxiv_id="2401.00001"))
+    assert service.last.subject == \
+        "arXiv replacement 12345 for 2401.00001 by Sam Submitter"
+
+
+def test_withdrawal_subject():
+    service = EmailInMemory()
+    _event().execute(_Api(service),
+                     _submission(SubmissionType.WITHDRAWAL, arxiv_id="2401.00001"))
+    sent = service.last
+    assert sent.subject == "arXiv withdrawal 12345 for 2401.00001 by Sam Submitter"
+    assert "View the withdrawal:" in sent.body
+
+
+def test_cross_subject_and_body():
+    service = EmailInMemory()
+    _event().execute(_Api(service),
+                     _submission(SubmissionType.CROSS_LIST, arxiv_id="2401.00001"))
+    sent = service.last
+    assert sent.subject == \
+        "arXiv cross 12345 to astro-ph.GA for 2401.00001 by Sam Submitter"
+    assert "A crosslist has been added by submitter Sam Submitter" in sent.body
+
+
+# --- execute(): recipient resolution ---
+
+def test_categories_to_email_includes_unresolved_proposals():
+    proposals = {
+        "p1": Proposal(proposal_id="p1", category="math.AG", is_primary=False,
+                       creator=agent.System(name="cls"),
+                       status=ProposalStatus.UNRESOLVED),
+        "p2": Proposal(proposal_id="p2", category="cs.AI", is_primary=True,
+                       creator=agent.System(name="cls"),
+                       status=ProposalStatus.REJECTED),
+    }
+    sub = _submission(proposals=proposals)
+    # Primary astro-ph.GA + unresolved math.AG; rejected cs.AI excluded.
+    assert _event().categories_to_email(sub) == ["astro-ph.GA", "math.AG"]
+
+
+# --- execute(): non-fatal failure modes ---
+
+def test_send_failure_is_recorded_not_raised():
+    class _Raising(EmailInMemory):
+        def send_email(self, *a, **k):
+            raise RuntimeError("smtp boom")
+
+    event = _event()
+    event.execute(_Api(_Raising()), _submission())  # must not raise
+    assert event.error is not None
+    assert "smtp boom" in event.error
+
+
+def test_no_service_records_error():
+    event = _event()
+    event.execute(_Api(None), _submission())
+    assert event.error is not None
+    assert "not configured" in event.error
+
+
+def test_project_is_noop():
+    sub = _submission()
+    assert _event().project(sub) is sub

--- a/submit_ce/domain/event/tests/test_email_mods.py
+++ b/submit_ce/domain/event/tests/test_email_mods.py
@@ -1,0 +1,192 @@
+"""Unit tests for `EmailProposalModeratorsMsg` and its emission.
+
+The event's `execute` side effect is exercised directly with hand-built
+submissions and a stub API, so no app, DB, or file store is needed. Sending must
+be non-fatal: a failure is recorded on `event.error`, never raised.
+"""
+from datetime import datetime
+
+from pytz import UTC
+
+from submit_ce.domain import agent
+from submit_ce.domain.meta import Classification
+from submit_ce.domain.config import SubmitConfig
+from submit_ce.domain.moderator import Moderator
+from submit_ce.domain.event import (
+    EmailProposalModeratorsMsg,
+    ProposeClassification,
+)
+from submit_ce.domain.submission import Submission, SubmissionMetadata
+from submit_ce.implementations.email.email_in_memory import EmailInMemory
+
+
+def _submitter():
+    return agent.PublicUser(name="Sam Submitter", user_id="u1",
+                            email="submitter@example.org", endorsements=[])
+
+
+def _submission():
+    u = _submitter()
+    return Submission(
+        submission_id="12345",
+        creator=u, owner=u, created=datetime.now(UTC),
+        primary_classification=Classification(category="astro-ph.GA"),
+        metadata=SubmissionMetadata(title="A Fine Paper"))
+
+
+def _mods():
+    return [
+        Moderator(user_id="2", email="ag@example.org", archive="math",
+                  subject_class="AG", name="Alice Gauss"),
+        Moderator(user_id="3", email="matharch@example.org", archive="math",
+                  subject_class="", name="Marc Archive"),
+    ]
+
+
+def _event(**kwargs):
+    defaults = dict(
+        creator=agent.System(name="test"),
+        submission_id="12345",
+        created=datetime.now(UTC),
+        categories=["math.AG"],
+        proposed_category="math.AG",
+        is_primary=False,
+        comment="please reclassify",
+        proposer_name="Mod Erator",
+    )
+    defaults.update(kwargs)
+    return EmailProposalModeratorsMsg(**defaults)
+
+
+class _Api:
+    """Stub exposing get_email_service, get_config, moderators_for_categories."""
+    def __init__(self, service, mods=None, config=None):
+        self._service = service
+        self._mods = mods if mods is not None else _mods()
+        # Explicit addresses (the domain defaults are non-real placeholders).
+        self._config = config or SubmitConfig(
+            mod_reply_to_email="mod-admin-email@arxiv.example.org",
+            archival_email="local-admin-email@arxiv.example.org")
+
+    def get_email_service(self):
+        return self._service
+
+    def get_config(self):
+        return self._config
+
+    def moderators_for_categories(self, categories):
+        return list(self._mods)
+
+
+# --- execute() ---
+
+def test_sends_to_moderators_with_expected_headers():
+    service = EmailInMemory()
+    event = _event()
+    event.execute(_Api(service), _submission())
+
+    assert event.error is None
+    sent = service.last
+    assert sent.to == ["ag@example.org", "matharch@example.org"]
+    # Reply-To = mod-admin then the moderator addresses.
+    assert sent.reply_to == \
+        "mod-admin-email@arxiv.example.org,ag@example.org,matharch@example.org"
+    assert sent.bcc == ["local-admin-email@arxiv.example.org"]
+
+
+def test_submitter_is_never_a_recipient():
+    service = EmailInMemory()
+    event = _event()
+    event.execute(_Api(service), _submission())
+    sent = service.last
+    recipients = sent.to + sent.bcc + [sent.reply_to]
+    assert all("submitter@example.org" not in r for r in recipients)
+
+
+def test_subject_and_body_content():
+    service = EmailInMemory()
+    event = _event()
+    event.execute(_Api(service), _submission())
+    sent = service.last
+    assert sent.subject == \
+        "Re: arXiv submission 12345 to astro-ph.GA by Sam Submitter"
+    assert "Proposed: math.AG as secondary" in sent.body
+    assert "please reclassify" in sent.body
+    assert "Mod Erator" in sent.body
+
+
+def test_no_moderators_falls_back_to_local_admin():
+    service = EmailInMemory()
+    event = _event()
+    event.execute(_Api(service, mods=[]), _submission())
+    sent = service.last
+    assert sent.to == ["local-admin-email@arxiv.example.org"]
+    assert sent.reply_to == "mod-admin-email@arxiv.example.org"
+    assert sent.bcc == []
+
+
+def test_send_failure_is_recorded_not_raised():
+    class _Raising(EmailInMemory):
+        def send_email(self, *a, **k):
+            raise RuntimeError("smtp boom")
+
+    event = _event()
+    event.execute(_Api(_Raising()), _submission())  # must not raise
+    assert event.error is not None
+    assert "smtp boom" in event.error
+
+
+def test_no_service_records_error():
+    event = _event()
+    event.execute(_Api(None), _submission())
+    assert event.error is not None
+    assert "not configured" in event.error
+
+
+def test_project_is_noop():
+    sub = _submission()
+    assert _event().project(sub) is sub
+
+
+# --- ProposeClassification.consequences() emission ---
+
+def _moderator_user():
+    return agent.StaffUser(user_id="4242", email="mod@arxiv.org",
+                           name="Mod Erator", username="moderator")
+
+
+def test_moderator_proposal_emits_one_email_event():
+    sub = _submission()
+    e = ProposeClassification(creator=_moderator_user(),
+                              created=datetime.now(UTC),
+                              category="math.AG",
+                              is_primary=False,
+                              comment="x")
+    after = e.apply(sub)
+    consequences = e.get_consequences(after)
+    assert len(consequences) == 1
+    msg = consequences[0]
+    assert isinstance(msg, EmailProposalModeratorsMsg)
+    assert msg.proposed_category == "math.AG"
+    assert msg.proposer_name == "Mod Erator"
+    assert msg.categories_to_email(sub) == ["math.AG"]
+
+
+def test_primary_proposal_includes_current_primary_category():
+    sub = _submission()  # current primary astro-ph.GA
+    e = ProposeClassification(creator=_moderator_user(),
+                              created=datetime.now(UTC),
+                              category="math.AG", is_primary=True)
+    after = e.apply(sub)
+    msg = e.get_consequences(after)[0]
+    # Moderators of both the proposed and the current primary are notified.
+    assert msg.categories_to_email(sub) == ["astro-ph.GA", "math.AG"]
+
+
+def test_system_proposal_emits_no_email():
+    sub = _submission()
+    e = ProposeClassification(creator=agent.System(name="classifier"),
+                              created=datetime.now(UTC),
+                              category="math.AG", is_primary=True)
+    after = e.apply(sub)
+    assert e.get_consequences(after) == []

--- a/submit_ce/domain/event/tests/test_email_mods.py
+++ b/submit_ce/domain/event/tests/test_email_mods.py
@@ -16,6 +16,7 @@ from submit_ce.domain.event import (
     EmailProposalModeratorsMsg,
     ProposeClassification,
 )
+from submit_ce.domain.proposal import Proposal, ProposalStatus
 from submit_ce.domain.submission import Submission, SubmissionMetadata
 from submit_ce.implementations.email.email_in_memory import EmailInMemory
 
@@ -190,3 +191,88 @@ def test_system_proposal_emits_no_email():
                               category="math.AG", is_primary=True)
     after = e.apply(sub)
     assert e.get_consequences(after) == []
+
+
+# --- Which moderators actually receive the email ---
+#
+# These exercise the full recipient resolution (execute -> categories_to_email
+# -> moderators_for_categories -> To addresses) with a per-category moderator
+# resolver, so we can assert on the concrete recipient addresses rather than
+# just on the category list.
+
+def _add_proposal(sub, category, is_primary,
+                  status=ProposalStatus.UNRESOLVED):
+    """Attach a proposal for ``category`` to ``sub`` and return ``sub``."""
+    pid = f"p-{category}-{'pri' if is_primary else 'sec'}"
+    sub.proposals[pid] = Proposal(
+        proposal_id=pid, category=category, is_primary=is_primary,
+        creator=_moderator_user(), created=datetime.now(UTC), status=status)
+    return sub
+
+
+class _PerCategoryApi(_Api):
+    """Resolve one distinct moderator per category.
+
+    ``moderators_for_categories`` returns the union of moderators for exactly
+    the requested categories (unknown categories resolve to nothing), so the
+    ``To`` list reflects which categories the event chose to notify.
+    """
+
+    CATEGORY_MODS = {
+        "astro-ph.GA": Moderator(user_id="10", email="mod-astro@example.org",
+                                 archive="astro-ph", subject_class="GA"),
+        "math.AG": Moderator(user_id="11", email="mod-mathag@example.org",
+                             archive="math", subject_class="AG"),
+        "cs.LG": Moderator(user_id="12", email="mod-cslg@example.org",
+                           archive="cs", subject_class="LG"),
+        "math.CO": Moderator(user_id="13", email="mod-mathco@example.org",
+                             archive="math", subject_class="CO"),
+        "q-bio.NC": Moderator(user_id="14", email="mod-qbio@example.org",
+                              archive="q-bio", subject_class="NC"),
+    }
+
+    def moderators_for_categories(self, categories):
+        return [self.CATEGORY_MODS[c] for c in categories
+                if c in self.CATEGORY_MODS]
+
+
+def test_primary_proposal_emails_current_proposed_and_unresolved_primary_mods():
+    service = EmailInMemory()
+    sub = _submission()  # current primary astro-ph.GA
+    _add_proposal(sub, "cs.LG", is_primary=True)   # unresolved primary
+    _add_proposal(sub, "math.CO", is_primary=True)  # unresolved primary
+    # A resolved primary proposal and an unresolved secondary must NOT pull in
+    # their moderators for a primary proposal.
+    _add_proposal(sub, "q-bio.NC", is_primary=True,
+                  status=ProposalStatus.REJECTED)
+    _add_proposal(sub, "math.AG", is_primary=False)
+
+    event = _event(proposed_category="math.AG", is_primary=True)
+    event.execute(_PerCategoryApi(service), sub)
+
+    assert event.error is None
+    assert set(service.last.to) == {
+        "mod-astro@example.org",   # current primary
+        "mod-mathag@example.org",  # proposed primary
+        "mod-cslg@example.org",    # unresolved primary proposal
+        "mod-mathco@example.org",  # unresolved primary proposal
+    }
+    # The rejected primary proposal's moderator is not notified.
+    assert "mod-qbio@example.org" not in service.last.to
+
+
+def test_secondary_proposal_emails_only_proposed_category_mod():
+    service = EmailInMemory()
+    sub = _submission()  # current primary astro-ph.GA
+    _add_proposal(sub, "cs.LG", is_primary=True)  # unresolved primary proposal
+
+    event = _event(proposed_category="math.AG", is_primary=False)
+    event.execute(_PerCategoryApi(service), sub)
+
+    assert event.error is None
+    # Only the proposed secondary's moderator is notified.
+    assert service.last.to == ["mod-mathag@example.org"]
+    # Neither the current primary's moderator nor the unresolved primary
+    # proposal's moderator receive the email.
+    assert "mod-astro@example.org" not in service.last.to
+    assert "mod-cslg@example.org" not in service.last.to

--- a/submit_ce/domain/event/tests/test_finalize_oversize_hold.py
+++ b/submit_ce/domain/event/tests/test_finalize_oversize_hold.py
@@ -11,8 +11,8 @@ from pytz import UTC
 from submit_ce.domain import agent
 from submit_ce.domain.meta import Classification
 from submit_ce.domain.event import FinalizeSubmission, AddHold, \
-    EmailSubmitterFinalizeMsg
-from submit_ce.domain.submission import Submission, Hold, Waiver
+    EmailSubmitterFinalizeMsg, EmailModeratorsFinalizeMsg
+from submit_ce.domain.submission import Submission, Hold, Waiver, SubmissionType
 
 
 def _user():
@@ -20,13 +20,18 @@ def _user():
                             email="u1@example.org", endorsements=[])
 
 
-def _submission(is_oversize=False, waivers=None):
+def _submission(is_oversize=False, waivers=None, submission_type=SubmissionType.NEW):
     u = _user()
     return Submission(
         creator=u, owner=u, created=datetime.now(UTC),
         primary_classification=Classification(category="astro-ph.GA"),
         is_oversize=is_oversize,
+        submission_type=submission_type,
         waivers=waivers or {})
+
+
+def _mod_emails(events):
+    return [e for e in events if isinstance(e, EmailModeratorsFinalizeMsg)]
 
 
 def _finalize():
@@ -65,4 +70,29 @@ def test_finalize_always_emails_submitter():
 
 def test_declared_consequence_type():
     assert FinalizeSubmission.CONSEQUENCE_TYPES == frozenset(
-        {AddHold, EmailSubmitterFinalizeMsg})
+        {AddHold, EmailSubmitterFinalizeMsg, EmailModeratorsFinalizeMsg})
+
+
+def test_new_finalize_emails_moderators():
+    """A plain `new` submission notifies moderators on finalize."""
+    events = _finalize().consequences(_submission())
+    assert len(_mod_emails(events)) == 1
+
+
+def test_auto_hold_finalize_does_not_email_moderators():
+    """An auto-held (oversize) submission tells the submitter, not moderators."""
+    events = _finalize().consequences(_submission(is_oversize=True))
+    assert _mod_emails(events) == []
+
+
+def test_jref_finalize_does_not_email_moderators():
+    """`jref` has no moderator template in legacy; no moderator email."""
+    sub = _submission(submission_type=SubmissionType.JOURNAL_REFERENCE)
+    assert _mod_emails(_finalize().consequences(sub)) == []
+
+
+def test_rep_wdr_cross_finalize_email_moderators():
+    for sub_type in (SubmissionType.REPLACEMENT, SubmissionType.WITHDRAWAL,
+                     SubmissionType.CROSS_LIST):
+        events = _finalize().consequences(_submission(submission_type=sub_type))
+        assert len(_mod_emails(events)) == 1, sub_type

--- a/submit_ce/domain/event/tests/test_propose_classification.py
+++ b/submit_ce/domain/event/tests/test_propose_classification.py
@@ -1,0 +1,81 @@
+"""Tests for :class:`.ProposeClassification`."""
+
+from datetime import datetime
+from unittest import TestCase
+
+from pytz import UTC
+
+from submit_ce.domain import event, agent, submission, meta
+from submit_ce.domain.proposal import ProposalStatus
+from submit_ce.domain.exceptions import InvalidEvent
+
+user = agent.PublicUser(
+    name="Bob Somebody",
+    user_id="12345",
+    email="uuser@cornell.edu",
+    endorsements=["astro-ph.GA", "astro-ph.CO"],
+)
+
+
+class TestProposeClassification(TestCase):
+    """Test recording a category proposal on a submission."""
+
+    def setUp(self):
+        self.user = user
+        self.submission = submission.Submission(
+            submission_id="1",
+            status=submission.Submission.WORKING,
+            creator=self.user,
+            owner=self.user,
+            created=datetime.now(UTC),
+            primary_classification=meta.Classification("astro-ph.GA"),
+        )
+
+    def _propose(self, category="cs.AI", is_primary=True, comment="please"):
+        return event.ProposeClassification(
+            creator=self.user, created=datetime.now(UTC),
+            category=category, is_primary=is_primary, comment=comment)
+
+    def test_propose_primary_records_proposal(self):
+        """A primary proposal is recorded as an unresolved Proposal."""
+        e = self._propose(category="cs.AI", is_primary=True)
+        after = e.apply(self.submission)
+        self.assertEqual(len(after.proposals), 1)
+        proposal = next(iter(after.proposals.values()))
+        self.assertEqual(proposal.category, "cs.AI")
+        self.assertTrue(proposal.is_primary)
+        self.assertEqual(proposal.status, ProposalStatus.UNRESOLVED)
+        self.assertTrue(proposal.is_unresolved)
+        self.assertEqual(proposal.comment, "please")
+
+    def test_propose_secondary_is_not_primary(self):
+        """A cross-list proposal has ``is_primary`` False."""
+        e = self._propose(category="astro-ph.CO", is_primary=False)
+        after = e.apply(self.submission)
+        proposal = next(iter(after.proposals.values()))
+        self.assertFalse(proposal.is_primary)
+
+    def test_proposal_does_not_change_classification(self):
+        """Proposing does not alter the submission's actual categories."""
+        e = self._propose(category="cs.AI", is_primary=True)
+        after = e.apply(self.submission)
+        self.assertEqual(after.primary_classification.category, "astro-ph.GA")
+
+    def test_missing_category_is_invalid(self):
+        e = event.ProposeClassification(creator=self.user,
+                                        created=datetime.now(UTC))
+        with self.assertRaises(InvalidEvent):
+            e.validate_pre_lock(self.submission)
+
+    def test_inactive_category_is_invalid(self):
+        e = self._propose(category="not.a.category")
+        with self.assertRaises(InvalidEvent):
+            e.validate_pre_lock(self.submission)
+
+    def test_duplicate_unresolved_proposal_is_invalid(self):
+        """The same category cannot be proposed twice while unresolved."""
+        first = self._propose(category="cs.AI", is_primary=True)
+        after = first.apply(self.submission)
+        second = self._propose(category="cs.AI", is_primary=True)
+        with self.assertRaises(InvalidEvent):
+            second.validate_pre_lock(after)

--- a/submit_ce/domain/moderator.py
+++ b/submit_ce/domain/moderator.py
@@ -1,0 +1,40 @@
+"""Moderators of categories and archives.
+
+A :class:`.Moderator` is the resolution of a classic ``arXiv_moderators`` row to
+a notifiable person: a user (with an email address) responsible for a category
+or, when ``subject_class`` is empty, a whole archive. This is decoupled from
+SQLAlchemy so the recipient-resolution logic and downstream email code do not
+depend on the ORM.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Moderator:
+    """A user assigned to moderate a category or an entire archive."""
+
+    user_id: str
+    email: str
+    archive: str
+    subject_class: str = ""
+    """The subject class, or ``""`` for an archive-level moderator."""
+
+    name: Optional[str] = field(default=None)
+
+    no_email: bool = field(default=False)
+    no_web_email: bool = field(default=False)
+    no_reply_to: bool = field(default=False)
+
+    @property
+    def is_archive_level(self) -> bool:
+        """Whether this moderator covers the whole archive."""
+        return self.subject_class == ""
+
+    @property
+    def category(self) -> str:
+        """The category id this assignment covers (archive id if archive-level)."""
+        if self.is_archive_level:
+            return self.archive
+        return f"{self.archive}.{self.subject_class}"

--- a/submit_ce/domain/proposal.py
+++ b/submit_ce/domain/proposal.py
@@ -1,0 +1,63 @@
+"""Category proposals on submissions.
+
+A :class:`.Proposal` records a suggested change to a submission's primary or
+cross-list classification. In the classic system these are generated both
+automatically (based on the classifier) and manually (by moderators), and are
+stored in the ``arXiv_submission_category_proposal`` table.
+
+This models proposal *creation* only. Proposal responses (accept/reject) are not
+modeled yet, so a freshly created proposal is always
+:attr:`ProposalStatus.UNRESOLVED`. The four-value enum mirrors the classic
+``proposal_status`` column so that responses can be added later without changing
+the on-disk representation.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import IntEnum
+from typing import Optional
+
+from .agent import User
+
+
+class ProposalStatus(IntEnum):
+    """Values mirror the classic ``proposal_status`` column exactly."""
+
+    UNRESOLVED = 0
+    ACCEPTED_AS_PRIMARY = 1
+    ACCEPTED_AS_SECONDARY = 2
+    REJECTED = 3
+
+
+@dataclass
+class Proposal:
+    """A proposed primary or cross-list classification for a submission."""
+
+    proposal_id: str
+    """Identifier for the proposal.
+
+    For a proposal created in this session it is the ``event_id`` of the
+    proposing event; for one loaded back from the classic database it is the
+    classic autoincrement ``proposal_id`` (also kept in
+    :attr:`classic_proposal_id`)."""
+
+    category: str
+    """The proposed category."""
+
+    is_primary: bool
+    """``True`` for a primary proposal, ``False`` for a cross-list proposal."""
+
+    creator: User
+    """The agent that made the proposal (a moderator, or the system)."""
+
+    created: Optional[datetime] = field(default=None)
+    comment: Optional[str] = field(default=None)
+    status: ProposalStatus = field(default=ProposalStatus.UNRESOLVED)
+
+    classic_proposal_id: Optional[int] = field(default=None)
+    """The autoincrement ``proposal_id`` from the classic table once persisted."""
+
+    @property
+    def is_unresolved(self) -> bool:
+        """Whether the proposal is still awaiting a response."""
+        return self.status == ProposalStatus.UNRESOLVED

--- a/submit_ce/domain/proposal.py
+++ b/submit_ce/domain/proposal.py
@@ -28,6 +28,7 @@ class ProposalStatus(IntEnum):
     ACCEPTED_AS_SECONDARY = 2
     REJECTED = 3
 
+    UNKNOWN = 404 # to represent an unexpected value from db
 
 @dataclass
 class Proposal:

--- a/submit_ce/domain/submission.py
+++ b/submit_ce/domain/submission.py
@@ -13,6 +13,7 @@ from .annotation import Comment, Feature, Annotation
 from .flag import Flag
 from .meta import License, Classification
 from .preview import Preview
+from .proposal import Proposal
 from .process import ProcessStatus
 from .util import get_tzaware_utc_now
 
@@ -344,6 +345,9 @@ class Submission:
 
     comments: Dict[str, Comment] = field(default_factory=dict)
     """Moderation/administrative comments."""
+
+    proposals: Dict[str, Proposal] = field(default_factory=dict)
+    """Category proposals (classifier- or moderator-suggested category changes)."""
 
     holds: Dict[str, Hold] = field(default_factory=dict)
     """Quality control holds."""

--- a/submit_ce/implementations/__init__.py
+++ b/submit_ce/implementations/__init__.py
@@ -9,7 +9,8 @@ from submit_ce.api.compile_service import CompileService
 from submit_ce.api.email_service import EmailService
 from submit_ce.domain.uploads import SubmitFile
 from submit_ce.domain.uploads import FileStatus, UploadStatus, UploadLifecycleStates
-from submit_ce.domain import Event, Submission, License, User, Client, Workspace
+from submit_ce.domain import Event, Submission, License, User, Client, Workspace, \
+    Moderator
 from submit_ce.domain.event.process import Result
 from submit_ce.domain.process import ProcessStatus
 from submit_ce.implementations.schedule import next_announcement_time, next_freeze_time
@@ -255,6 +256,10 @@ class NullImplementation(SubmitApi):  # pragma: no cover
 
     def get_email_service(self) -> EmailService:
         return NullEmailService()
+
+    def moderators_for_categories(self, categories: List[str]) \
+            -> List[Moderator]:
+        return []
 
     def get(self, submission_id: str) -> Submission:
         Submission(submission_id)

--- a/submit_ce/implementations/__init__.py
+++ b/submit_ce/implementations/__init__.py
@@ -257,8 +257,14 @@ class NullImplementation(SubmitApi):  # pragma: no cover
     def get_email_service(self) -> EmailService:
         return NullEmailService()
 
-    def moderators_for_categories(self, categories: List[str]) \
-            -> List[Moderator]:
+    def moderators_for_categories(
+            self,
+            categories: List[str],
+            *,
+            exclude_no_web_email: bool = True,
+            exclude_no_email: bool = False,
+            exclude_no_reply_to: bool = False,
+    ) -> List[Moderator]:
         return []
 
     def get(self, submission_id: str) -> Submission:

--- a/submit_ce/implementations/legacy_implementation/__init__.py
+++ b/submit_ce/implementations/legacy_implementation/__init__.py
@@ -293,14 +293,24 @@ class LegacySubmitImplementation(SubmitApi):
         return self.email_service
 
     @override
-    def moderators_for_categories(self, categories: List[str]) \
-            -> List[Moderator]:
+    def moderators_for_categories(
+            self,
+            categories: List[str],
+            *,
+            exclude_no_web_email: bool = True,
+            exclude_no_email: bool = False,
+            exclude_no_reply_to: bool = False,
+    ) -> List[Moderator]:
         # Reuse the current (scoped) session without a `with` block: this is
         # called from within an event's execute(), inside the save() session, so
         # closing a nested context here would tear down the in-flight
         # transaction. The read runs in the same session/transaction.
         session = self.get_session()
-        return moderators.moderators_for_categories(session, categories)
+        return moderators.moderators_for_categories(
+            session, categories,
+            exclude_no_web_email=exclude_no_web_email,
+            exclude_no_email=exclude_no_email,
+            exclude_no_reply_to=exclude_no_reply_to)
 
     @override
     def get_config(self) -> SubmitConfig:

--- a/submit_ce/implementations/legacy_implementation/__init__.py
+++ b/submit_ce/implementations/legacy_implementation/__init__.py
@@ -295,8 +295,12 @@ class LegacySubmitImplementation(SubmitApi):
     @override
     def moderators_for_categories(self, categories: List[str]) \
             -> List[Moderator]:
-        with self.get_session() as session:
-            return moderators.moderators_for_categories(session, categories)
+        # Reuse the current (scoped) session without a `with` block: this is
+        # called from within an event's execute(), inside the save() session, so
+        # closing a nested context here would tear down the in-flight
+        # transaction. The read runs in the same session/transaction.
+        session = self.get_session()
+        return moderators.moderators_for_categories(session, categories)
 
     @override
     def get_config(self) -> SubmitConfig:

--- a/submit_ce/implementations/legacy_implementation/__init__.py
+++ b/submit_ce/implementations/legacy_implementation/__init__.py
@@ -13,6 +13,7 @@ from submit_ce.api import SubmitApi
 from submit_ce.api.email_service import EmailService
 from submit_ce.api.file_store import SubmissionFileStore
 from submit_ce.domain.agent import Client, User
+from submit_ce.domain import Moderator
 from submit_ce.domain.config import SubmitConfig
 from submit_ce.domain.meta import License
 from ...api.compile_service import CompileService
@@ -22,6 +23,7 @@ from ..schedule import next_announcement_time, next_freeze_time
 from .db import to_submission
 from .models import Submission
 from . import models
+from . import moderators
 
 from ...domain.event.base import Event, EventWithSideEffect
 from ...domain.util import get_tzaware_utc_now
@@ -289,6 +291,12 @@ class LegacySubmitImplementation(SubmitApi):
     @override
     def get_email_service(self) -> EmailService:
         return self.email_service
+
+    @override
+    def moderators_for_categories(self, categories: List[str]) \
+            -> List[Moderator]:
+        with self.get_session() as session:
+            return moderators.moderators_for_categories(session, categories)
 
     @override
     def get_config(self) -> SubmitConfig:

--- a/submit_ce/implementations/legacy_implementation/db.py
+++ b/submit_ce/implementations/legacy_implementation/db.py
@@ -47,7 +47,7 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session as SQLAlchemySession
 from sqlalchemy.orm.exc import NoResultFound
 
-from submit_ce.domain.agent import Client, HttpClient
+from submit_ce.domain.agent import Client, HttpClient, System
 from submit_ce.domain.event.legacy import Withdraw
 from submit_ce.domain.event.request import CancelRequest, RequestCrossList, RequestWithdrawal
 
@@ -58,7 +58,8 @@ from submit_ce import domain
 from submit_ce.domain.uploads import SourceFormat
 from submit_ce.domain import Event, Submission, User, WithdrawalRequest, CrossListClassificationRequest,  License
 from submit_ce.domain.submission import SubmissionType
-from submit_ce.domain.event import SetJournalReference, SetDOI, SetReportNumber, CreateSubmission, Rollback
+from submit_ce.domain.event import SetJournalReference, SetDOI, SetReportNumber, CreateSubmission, Rollback, \
+    ProposeClassification
 from submit_ce.domain.exceptions import NoSuchSubmission
 
 logger = logging.getLogger(__name__)
@@ -358,7 +359,70 @@ def store_event(session: SQLAlchemySession, event: Event, before: Optional[Submi
         assert before is not None
         event.submission_id = before.submission_id
         after.submission_id = before.submission_id
+
+    # Some events also write to auxiliary classic tables, keyed off the now-final
+    # submission_id. A category proposal records a row in
+    # arXiv_submission_category_proposal (and an accompanying admin log comment).
+    if isinstance(event, ProposeClassification):
+        _store_proposal(session, event, after)
+
     return event, after
+
+
+def _store_proposal(session: SQLAlchemySession, event: ProposeClassification,
+                    after: Submission) -> models.CategoryProposal:
+    """Record a category proposal in the classic database.
+
+    Mirrors the legacy ``system_propose_primary`` / ``save_new_proposals``
+    behaviour: insert one ``arXiv_submission_category_proposal`` row with
+    ``proposal_status = UNRESOLVED`` and an ``arXiv_admin_log`` comment row,
+    linked via ``proposal_comment_id``.
+    """
+    assert event.category is not None
+    user_id = _proposer_user_id(session, event.creator)
+
+    type_str = "primary" if event.is_primary else "secondary"
+    logtext = f"Proposed: {event.category} as {type_str}"
+    if event.comment:
+        logtext += f": {event.comment}"
+    username = "system" if isinstance(event.creator, System) \
+        else str(event.creator.identifier)
+    comment = log.admin_log(session, "Submission", "admin comment", logtext,
+                            username=username,
+                            submission_id=after.submission_id)
+    # Flush so the comment row gets an id to reference from the proposal.
+    if comment is not None:
+        session.flush([comment])
+
+    proposal = models.CategoryProposal(
+        submission_id=after.submission_id,
+        category=event.category,
+        is_primary=1 if event.is_primary else 0,
+        proposal_status=models.CategoryProposal.UNRESOLVED,
+        user_id=user_id,
+        updated=event.created,
+        proposal_comment_id=comment.id if comment is not None else None,
+    )
+    session.add(proposal)
+    session.flush([proposal])
+    return proposal
+
+
+def _proposer_user_id(session: SQLAlchemySession, creator: User) -> int:
+    """Resolve the tapir ``user_id`` for the agent making a proposal.
+
+    Moderators carry their own tapir id; system/classifier proposals are
+    attributed to the configured ``system`` user (legacy looks this up by the
+    ``system`` nickname in ``tapir_nicknames``).
+    """
+    if isinstance(creator, System):
+        row = session.query(models.Username) \
+            .filter_by(nickname="system").first()
+        if row is None:
+            raise RuntimeError(
+                "No 'system' user configured for system-generated proposals")
+        return int(row.user_id)
+    return int(creator.identifier)
 
 
 def _load(session: SQLAlchemySession,
@@ -707,7 +771,35 @@ def to_submission(row: models.Submission,
     if row.sticky_status == row.ON_HOLD or row.status == row.ON_HOLD:
         submission = patch_hold(submission, row)
 
+    for prop in row.category_proposals:
+        submission.proposals[str(prop.proposal_id)] = _to_proposal(prop)
+
     return submission
+
+
+def _to_proposal(row: models.CategoryProposal) -> domain.Proposal:
+    """Build a domain :class:`.Proposal` from a classic proposal row."""
+    proposer = row.user
+    if proposer is not None:
+        name = f"{proposer.first_name or ''} {proposer.last_name or ''}".strip()
+        creator: domain.User = domain.PublicUser(
+            user_id=str(row.user_id),
+            name=name or "unknown",
+            email=proposer.email or "unknown")
+    else:
+        creator = domain.PublicUser(user_id=str(row.user_id),
+                                    name="unknown", email="unknown")
+    comment = row.proposal_comment.logtext if row.proposal_comment else None
+    return domain.Proposal(
+        proposal_id=str(row.proposal_id),
+        category=row.category,
+        is_primary=bool(row.is_primary),
+        creator=creator,
+        created=row.updated,
+        comment=comment,
+        status=domain.ProposalStatus(row.proposal_status or 0),
+        classic_proposal_id=row.proposal_id,
+    )
 
 
 def load(rows: Iterable[models.Submission]) -> Optional[domain.Submission]:

--- a/submit_ce/implementations/legacy_implementation/db.py
+++ b/submit_ce/implementations/legacy_implementation/db.py
@@ -790,6 +790,12 @@ def _to_proposal(row: models.CategoryProposal) -> domain.Proposal:
         creator = domain.PublicUser(user_id=str(row.user_id),
                                     name="unknown", email="unknown")
     comment = row.proposal_comment.logtext if row.proposal_comment else None
+
+    if row.proposal_status in iter(domain.ProposalStatus):
+        status = domain.ProposalStatus(row.proposal_status)
+    else:
+        status = domain.ProposalStatus.UNKNOWN
+
     return domain.Proposal(
         proposal_id=str(row.proposal_id),
         category=row.category,
@@ -797,7 +803,7 @@ def _to_proposal(row: models.CategoryProposal) -> domain.Proposal:
         creator=creator,
         created=row.updated,
         comment=comment,
-        status=domain.ProposalStatus(row.proposal_status or 0),
+        status=status,
         classic_proposal_id=row.proposal_id,
     )
 

--- a/submit_ce/implementations/legacy_implementation/log.py
+++ b/submit_ce/implementations/legacy_implementation/log.py
@@ -113,16 +113,17 @@ def admin_log(session: SQLAlchemySession,
     """
     if paper_id is None and submission_id is not None:
         paper_id = f'submit/{submission_id}'
-        entry = models.AdminLogEntry(
-            paper_id=paper_id,
-            username=username,
-            host=hostname,
-            program=program,
-            command=command,
-            logtext=text,
-            document_id=document_id,
-            submission_id=submission_id,
-            notify=notify
-        )
-        session.add(entry)
-        return entry
+
+    entry = models.AdminLogEntry(
+        paper_id=paper_id[:20] if paper_id else "",
+        username=username[:20] if username else "",
+        host=hostname[:64] if hostname else "",
+        program=program[:20] if program else "",
+        command=command[:20] if command else "",
+        logtext=text,
+        document_id=document_id,
+        submission_id=submission_id,
+        notify=notify
+    )
+    session.add(entry)
+    return entry

--- a/submit_ce/implementations/legacy_implementation/models.py
+++ b/submit_ce/implementations/legacy_implementation/models.py
@@ -703,6 +703,43 @@ class User(Base):    # type: ignore
     tapir_policy_class = relationship('PolicyClass')
 
 
+class Moderator(Base):    # type: ignore
+    """
+    Assignment of a user as moderator of a category or whole archive.
+
+    An empty ``subject_class`` (``''``) denotes an archive-level moderator that
+    covers every subject class in ``archive``.
+
+    +---------------+-------------+------+-----+---------+
+    | Field         | Type        | Null | Key | Default |
+    +---------------+-------------+------+-----+---------+
+    | user_id       | int(4)      | NO   | PRI | NULL    |
+    | archive       | varchar(16) | NO   | PRI |         |
+    | subject_class | varchar(16) | NO   | PRI |         |
+    | is_public     | tinyint(1)  | NO   |     | 0       |
+    | no_email      | tinyint(1)  | YES  |     | 0       |
+    | no_web_email  | tinyint(1)  | YES  |     | 0       |
+    | no_reply_to   | tinyint(1)  | YES  |     | 0       |
+    | daily_update  | tinyint(1)  | YES  |     | 0       |
+    +---------------+-------------+------+-----+---------+
+    """
+
+    __tablename__ = 'arXiv_moderators'
+
+    user_id = Column(ForeignKey('tapir_users.user_id'), primary_key=True,
+                     index=True)
+    archive = Column(String(16), primary_key=True, server_default=text("''"))
+    subject_class = Column(String(16), primary_key=True,
+                           server_default=text("''"))
+    is_public = Column(Integer, nullable=False, server_default=text("'0'"))
+    no_email = Column(Integer, nullable=True, server_default=text("'0'"))
+    no_web_email = Column(Integer, nullable=True, server_default=text("'0'"))
+    no_reply_to = Column(Integer, nullable=True, server_default=text("'0'"))
+    daily_update = Column(Integer, nullable=True, server_default=text("'0'"))
+
+    user = relationship('User')
+
+
 class Username(Base):  # type: ignore
     """
     Users' usernames (because why not have a separate table).

--- a/submit_ce/implementations/legacy_implementation/models.py
+++ b/submit_ce/implementations/legacy_implementation/models.py
@@ -228,6 +228,11 @@ class Submission(Base):    # type: ignore
     categories = relationship('SubmissionCategory',
                               back_populates='submission', lazy='joined',
                               cascade="all, delete-orphan")
+    category_proposals = relationship(
+        'CategoryProposal',
+        primaryjoin='Submission.submission_id == foreign(CategoryProposal.submission_id)',
+        viewonly=True,
+    )
 
     def get_submitter(self) -> domain.PublicUser:
         """Generate a :class:`.User` representing the submitter."""

--- a/submit_ce/implementations/legacy_implementation/moderators.py
+++ b/submit_ce/implementations/legacy_implementation/moderators.py
@@ -1,0 +1,102 @@
+"""Resolve which moderators should be notified for a set of categories.
+
+A Python port of the legacy recipient logic
+(``arXiv::Submit::Email::SubmissionEmailLists::get_mod_email_to`` plus
+``CategoryDef::moderators`` / ``archive_moderators``): for each category include
+both the category-level moderators and the archive-level moderators
+(``subject_class == ''``), apply opt-out filters, and de-duplicate by email.
+"""
+
+from typing import Iterable, List, Tuple
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Session as SQLAlchemySession
+
+from submit_ce import domain
+from . import models
+
+
+def split_category(category: str) -> Tuple[str, str]:
+    """Split a category id into ``(archive, subject_class)``.
+
+    ``'math.AG'`` -> ``('math', 'AG')``; ``'hep-th'`` -> ``('hep-th', '')``.
+    Mirrors the way the classic ``category`` column is decomposed.
+    """
+    archive, _, subject_class = category.partition('.')
+    return archive, subject_class
+
+
+def moderators_for_categories(
+        session: SQLAlchemySession,
+        categories: Iterable[str],
+        *,
+        exclude_no_web_email: bool = True,
+        exclude_no_email: bool = False,
+        exclude_no_reply_to: bool = False,
+) -> List[domain.Moderator]:
+    """Resolve categories to the moderators that should be notified.
+
+    For each category, both category-level moderators
+    (``archive == A and subject_class == S``) and archive-level moderators
+    (``archive == A and subject_class == ''``) are included. The opt-out filters
+    drop moderators who have set the corresponding flag; the default mirrors
+    legacy proposal emails, which exclude ``no_web_email`` moderators.
+
+    Returns moderators de-duplicated by email and sorted by email.
+    """
+    # Gather the distinct (archive, subject_class) pairs to look up: the
+    # category itself and its archive-level entry.
+    pairs = set()
+    for category in categories:
+        archive, subject_class = split_category(category)
+        pairs.add((archive, subject_class))
+        pairs.add((archive, ''))
+
+    if not pairs:
+        return []
+
+    conditions = [
+        and_(models.Moderator.archive == archive,
+             models.Moderator.subject_class == subject_class)
+        for archive, subject_class in pairs
+    ]
+    rows = session.query(models.Moderator).filter(or_(*conditions)).all()
+
+    by_email: dict[str, domain.Moderator] = {}
+    for row in rows:
+        if exclude_no_web_email and row.no_web_email:
+            continue
+        if exclude_no_email and row.no_email:
+            continue
+        if exclude_no_reply_to and row.no_reply_to:
+            continue
+        email = row.user.email if row.user else None
+        if not email or email in by_email:
+            continue
+        proposer = row.user
+        name = None
+        if proposer is not None:
+            name = f"{proposer.first_name or ''} {proposer.last_name or ''}".strip() \
+                or None
+        by_email[email] = domain.Moderator(
+            user_id=str(row.user_id),
+            email=email,
+            archive=row.archive,
+            subject_class=row.subject_class or '',
+            name=name,
+            no_email=bool(row.no_email),
+            no_web_email=bool(row.no_web_email),
+            no_reply_to=bool(row.no_reply_to),
+        )
+
+    return [by_email[email] for email in sorted(by_email)]
+
+
+def moderator_emails(
+        session: SQLAlchemySession,
+        categories: Iterable[str],
+        **kwargs: bool,
+) -> List[str]:
+    """Sorted, de-duplicated moderator email addresses for the categories."""
+    return [m.email for m in
+            moderators_for_categories(session, categories, **kwargs)]

--- a/submit_ce/implementations/pubsub/__init__.py
+++ b/submit_ce/implementations/pubsub/__init__.py
@@ -54,9 +54,19 @@ class PubsubEventSubmitImplementation(SubmitApi):
     def get_email_service(self) -> EmailService:
         return self.inner_api.get_email_service()
 
-    def moderators_for_categories(self, categories: List[str]) \
-            -> List[Moderator]:
-        return self.inner_api.moderators_for_categories(categories)
+    def moderators_for_categories(
+            self,
+            categories: List[str],
+            *,
+            exclude_no_web_email: bool = True,
+            exclude_no_email: bool = False,
+            exclude_no_reply_to: bool = False,
+    ) -> List[Moderator]:
+        return self.inner_api.moderators_for_categories(
+            categories,
+            exclude_no_web_email=exclude_no_web_email,
+            exclude_no_email=exclude_no_email,
+            exclude_no_reply_to=exclude_no_reply_to)
 
     def get_config(self) -> SubmitConfig:
         return self.inner_api.get_config()

--- a/submit_ce/implementations/pubsub/__init__.py
+++ b/submit_ce/implementations/pubsub/__init__.py
@@ -7,7 +7,7 @@ import logging
 from google.cloud import pubsub_v1
 
 from submit_ce.api import SubmitApi, SubmissionFileStore
-from submit_ce.domain import Event, Submission
+from submit_ce.domain import Event, Submission, Moderator
 from submit_ce.api.compile_service import CompileService
 from submit_ce.api.email_service import EmailService
 from submit_ce.domain.config import SubmitConfig
@@ -53,6 +53,10 @@ class PubsubEventSubmitImplementation(SubmitApi):
 
     def get_email_service(self) -> EmailService:
         return self.inner_api.get_email_service()
+
+    def moderators_for_categories(self, categories: List[str]) \
+            -> List[Moderator]:
+        return self.inner_api.moderators_for_categories(categories)
 
     def get_config(self) -> SubmitConfig:
         return self.inner_api.get_config()

--- a/submit_ce/implementations/pubsub/tests/test_pubsub_impl.py
+++ b/submit_ce/implementations/pubsub/tests/test_pubsub_impl.py
@@ -72,8 +72,19 @@ def test_call_to_inner(submission_topic, project_id):
                 continue
 
             sig = inspect.signature(method)
-            call_args = [MagicMock() for name, _ in sig.parameters.items() if name not in ["self"]]
-            method(ps_impl, *call_args)
+            call_args = []
+            call_kwargs = {}
+            for pname, param in sig.parameters.items():
+                if pname == "self":
+                    continue
+                if param.kind in (inspect.Parameter.VAR_POSITIONAL,
+                                  inspect.Parameter.VAR_KEYWORD):
+                    continue
+                if param.kind == inspect.Parameter.KEYWORD_ONLY:
+                    call_kwargs[pname] = MagicMock()
+                else:
+                    call_args.append(MagicMock())
+            method(ps_impl, *call_args, **call_kwargs)
             time.sleep(0.07)
             mock_method = getattr(mock_api, name)
             assert mock_method and mock_method.call_count == 1

--- a/submit_ce/implementations/tests/test_moderators.py
+++ b/submit_ce/implementations/tests/test_moderators.py
@@ -1,0 +1,95 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from submit_ce.implementations.legacy_implementation.models import (
+    Base, User, Moderator,
+)
+from submit_ce.implementations.legacy_implementation.moderators import (
+    split_category,
+    moderators_for_categories,
+    moderator_emails,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _user(session, user_id, email, first="Mod", last="Erator"):
+    session.add(User(user_id=user_id, email=email,
+                     first_name=first, last_name=last))
+
+
+def _seed(session):
+    # math.AG category-level moderator
+    _user(session, 1, "ag@example.org", "Alice", "Gauss")
+    session.add(Moderator(user_id=1, archive="math", subject_class="AG"))
+    # math archive-level moderator (covers all of math)
+    _user(session, 2, "matharch@example.org", "Marc", "Archive")
+    session.add(Moderator(user_id=2, archive="math", subject_class=""))
+    # unrelated cs.AI moderator
+    _user(session, 3, "cs@example.org", "Carol", "Sharp")
+    session.add(Moderator(user_id=3, archive="cs", subject_class="AI"))
+    # math.AG moderator who opted out of web email
+    _user(session, 4, "noweb@example.org", "Nora", "Webless")
+    session.add(Moderator(user_id=4, archive="math", subject_class="AG",
+                          no_web_email=1))
+    session.commit()
+
+
+def test_split_category():
+    assert split_category("math.AG") == ("math", "AG")
+    assert split_category("hep-th") == ("hep-th", "")
+    assert split_category("astro-ph.GA") == ("astro-ph", "GA")
+
+
+def test_resolves_category_and_archive_level(db_session):
+    _seed(db_session)
+    mods = moderators_for_categories(db_session, ["math.AG"])
+    emails = [m.email for m in mods]
+    # category-level AG mod + archive-level math mod; excludes cs.AI and no_web.
+    assert emails == ["ag@example.org", "matharch@example.org"]
+    assert sorted(emails) == emails  # sorted by email
+
+
+def test_excludes_no_web_email_by_default(db_session):
+    _seed(db_session)
+    emails = moderator_emails(db_session, ["math.AG"])
+    assert "noweb@example.org" not in emails
+
+
+def test_include_no_web_email_when_not_excluded(db_session):
+    _seed(db_session)
+    emails = moderator_emails(db_session, ["math.AG"],
+                              exclude_no_web_email=False)
+    assert "noweb@example.org" in emails
+
+
+def test_dedupes_across_categories(db_session):
+    # An archive-level math moderator is reached by both math.AG and math.CO.
+    _seed(db_session)
+    mods = moderators_for_categories(db_session, ["math.AG", "math.CO"])
+    emails = [m.email for m in mods]
+    assert emails.count("matharch@example.org") == 1
+
+
+def test_unknown_category_returns_no_moderators(db_session):
+    _seed(db_session)
+    assert moderators_for_categories(db_session, ["q-bio.NC"]) == []
+
+
+def test_archive_level_flag_and_category(db_session):
+    _seed(db_session)
+    mods = {m.email: m for m in
+            moderators_for_categories(db_session, ["math.AG"])}
+    assert mods["matharch@example.org"].is_archive_level
+    assert mods["matharch@example.org"].category == "math"
+    assert not mods["ag@example.org"].is_archive_level
+    assert mods["ag@example.org"].category == "math.AG"

--- a/submit_ce/make_test_db.py
+++ b/submit_ce/make_test_db.py
@@ -173,6 +173,50 @@ def categories() -> List[models.CategoryDef]:
     ]
 
 
+# Deterministic moderators for testing/dev. Each tuple is
+# (user_id, email, first_name, last_name, archive, subject_class, no_web_email).
+# An empty subject_class denotes an archive-level moderator. These are used by
+# tests that exercise category->moderator resolution.
+MODERATORS: List[Tuple[int, str, str, str, str, str, int]] = [
+    (900001, "ag@example.org", "Alice", "Gauss", "math", "AG", 0),
+    (900002, "matharch@example.org", "Marc", "Archive", "math", "", 0),
+    (900003, "noweb@example.org", "Nora", "Webless", "math", "AG", 1),
+    (900004, "cs@example.org", "Carol", "Sharp", "cs", "AI", 0),
+]
+
+
+def moderator_users() -> List[models.TapirUser]:
+    """Tapir users that back the deterministic test moderators."""
+    return [
+        models.TapirUser(
+            user_id=user_id,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            policy_class=2,
+            flag_email_verified=1,
+            flag_approved=1,
+        )
+        for user_id, email, first_name, last_name, _arch, _sub, _noweb
+        in MODERATORS
+    ]
+
+
+def moderators() -> List[submit_ce_models.Moderator]:
+    """Moderator assignments for the deterministic test moderators."""
+    return [
+        submit_ce_models.Moderator(
+            user_id=user_id,
+            archive=archive,
+            subject_class=subject_class,
+            is_public=1,
+            no_web_email=no_web_email,
+        )
+        for user_id, _email, _first, _last, archive, subject_class, no_web_email
+        in MODERATORS
+    ]
+
+
 def policy_classes() -> List[models.TapirPolicyClass]:
     """Generate policy classes."""
     return [models.TapirPolicyClass(**datum) for datum in POLICY_CLASSES]
@@ -431,6 +475,14 @@ def bootstrap_db(
                 session.add(obj)
             session.commit()
             logger.debug("Added %i categories", len(categories()))
+
+            for obj in moderator_users():
+                session.add(obj)
+            session.commit()
+            for obj in moderators():
+                session.add(obj)
+            session.commit()
+            logger.debug("Added %i moderators", len(moderators()))
 
             #users_to_add = users_v2(10)
             users_to_add = users_v3(10)

--- a/submit_ce/make_test_db.py
+++ b/submit_ce/make_test_db.py
@@ -185,6 +185,28 @@ MODERATORS: List[Tuple[int, str, str, str, str, str, int]] = [
 ]
 
 
+SYSTEM_USER_ID = 900000
+
+
+def system_user() -> models.TapirUser:
+    """The ``system`` user that owns classifier/automated actions.
+
+    Resolved by ``nickname == 'system'`` when recording system-generated
+    category proposals (see ``legacy_implementation.db._proposer_user_id``).
+    """
+    return models.TapirUser(
+        user_id=SYSTEM_USER_ID,
+        email="system@arxiv.org",
+        first_name="arXiv",
+        last_name="System",
+        policy_class=2,
+        flag_email_verified=1,
+        flag_approved=1,
+        tapir_nicknames=models.TapirNickname(
+            nickname="system", flag_valid=1, flag_primary=1),
+    )
+
+
 def moderator_users() -> List[models.TapirUser]:
     """Tapir users that back the deterministic test moderators."""
     return [
@@ -475,6 +497,10 @@ def bootstrap_db(
                 session.add(obj)
             session.commit()
             logger.debug("Added %i categories", len(categories()))
+
+            session.add(system_user())
+            session.commit()
+            logger.debug("Added system user")
 
             for obj in moderator_users():
                 session.add(obj)

--- a/submit_ce/ui/config.py
+++ b/submit_ce/ui/config.py
@@ -127,22 +127,29 @@ class Settings(ArxivBaseSettings):
     resource name is passed straight through. Only used when
     ``EMAIL_MODE=HALON``."""
 
-    EMAIL_TIMEOUT: float = 30.0
+    EMAIL_TIMEOUT: float = 10.0
     """Timeout in seconds for SMTP connection and I/O. Applied to both the
     initial connection and all blocking socket operations (login, send).
     Only used when ``EMAIL_MODE=HALON``."""
 
-    EMAIL_FROM: str = "e-prints@arxiv.org"
-    """Default ``From`` address for outgoing mail. Matches legacy submission mail,
-    which sends from ``e-prints@arxiv.org``."""
+    EMAIL_FROM: str = "EMAIL_FROM@example.org"
+    """Default ``From`` address for outgoing mail. Matches legacy submission mail."""
 
-    EMAIL_REPLY_TO: str = "www-admin@arxiv.org"
+    EMAIL_REPLY_TO: str = "EMAIL_REPLY_TO@example.org"
     """``Reply-To`` address for email. Matches legacy, which used the
     configurable ``$WWW_ADMIN_ADDRESS``."""
 
-    EMAIL_AUTO_HOLD_REPLY_TO: str = "mod-lib@arxiv.org"
-    """``Reply-To`` address for auto-hold confirmation emails. Legacy uses
-    ``mod-lib@arxiv.org`` so replies go to the moderation team."""
+    EMAIL_AUTO_HOLD_REPLY_TO: str = "EMAIL_AUTO_HOLD_REPLY_TO@example.org"
+    """``Reply-To`` address for auto-hold confirmation emails so replies go to
+    the moderation team."""
+
+    MOD_REPLY_TO_EMAIL: str = "MOD_ADMIN_EMAIL@example.org"
+    """Moderation admin address; included in ``Reply-To`` on moderator
+    notification emails (e.g. category proposals)."""
+
+    ARCHIVAL_EMAIL: str = "LOCAL_ADMIN_EMAIL@example.org"
+    """Internal admin address; ``Bcc``'d on moderator notification emails, and
+    the ``To`` fallback when a proposed category has no moderators."""
 
     COMPILE_API_IMPERSONATE_SA: str = ""
     """Service account email to impersonate when minting ID tokens for the

--- a/submit_ce/ui/tests/test_finalize_emails_submitter.py
+++ b/submit_ce/ui/tests/test_finalize_emails_submitter.py
@@ -30,9 +30,11 @@ def test_finalize_sends_submitter_email(app, authorized_user, sub_metadata):
             current_app.api.email_service = original
 
         assert submission.status == Submission.SUBMITTED
-        assert len(service.sent) == 1
-        sent = service.last
-        assert sent.to == [submission.contact_email]
+        # Finalize also notifies moderators; pick out the submitter's email.
+        submitter_emails = [e for e in service.sent
+                            if e.to == [submission.contact_email]]
+        assert len(submitter_emails) == 1
+        sent = submitter_emails[0]
         assert sent.subject == f"arXiv submission {sid}"
         # Reply-To and dashboard URL are resolved from SubmitConfig, which the
         # backend builds from settings (BASE_SERVER substituted into the URL).

--- a/submit_ce/ui/tests/test_finalize_emails_submitter.py
+++ b/submit_ce/ui/tests/test_finalize_emails_submitter.py
@@ -36,7 +36,7 @@ def test_finalize_sends_submitter_email(app, authorized_user, sub_metadata):
         assert sent.subject == f"arXiv submission {sid}"
         # Reply-To and dashboard URL are resolved from SubmitConfig, which the
         # backend builds from settings (BASE_SERVER substituted into the URL).
-        assert sent.reply_to == "www-admin@arxiv.org"
+        assert sent.reply_to == "EMAIL_REPLY_TO@example.org"
         assert "/user/" in sent.body
         assert current_app.api.get_config().url_for_user_dashboard in sent.body
 

--- a/submit_ce/ui/tests/test_moderator_api.py
+++ b/submit_ce/ui/tests/test_moderator_api.py
@@ -1,0 +1,23 @@
+"""SubmitApi.moderators_for_categories through the real legacy implementation.
+
+The resolution logic itself is unit-tested in
+submit_ce/implementations/tests/test_moderators.py; this exercises the API seam
+and its session wiring against the app's database. The moderators it relies on
+are seeded by submit_ce.make_test_db.MODERATORS during bootstrap.
+"""
+
+from flask import current_app
+
+
+def test_moderators_for_categories_via_api(app, authorized_user):
+    with app.app_context():
+        mods = current_app.api.moderators_for_categories(["math.AG"])
+        emails = sorted(m.email for m in mods)
+
+        # math.AG category-level moderator + math archive-level moderator.
+        assert "ag@example.org" in emails
+        assert "matharch@example.org" in emails
+        # opted out of web email -> excluded by default
+        assert "noweb@example.org" not in emails
+        # moderator of an unrelated category -> not included
+        assert "cs@example.org" not in emails

--- a/submit_ce/ui/tests/test_proposal_email.py
+++ b/submit_ce/ui/tests/test_proposal_email.py
@@ -1,0 +1,70 @@
+"""End-to-end: making a proposal emails the category moderators.
+
+Runs a real ``save`` through the app (which uses the in-memory email service in
+TESTING mode) and asserts the moderator notification was sent. The moderators
+are seeded by ``submit_ce.make_test_db.MODERATORS``.
+"""
+
+from flask import current_app
+
+from submit_ce.domain.event import CreateSubmission, ProposeClassification
+from submit_ce.domain.agent import InternalClient
+
+
+def test_proposal_sends_moderator_email(app, authorized_user):
+    with app.app_context():
+        user = authorized_user
+        client = InternalClient(name="test_proposal_email")
+
+        service = current_app.api.email_service
+        service.clear()
+
+        submission, _ = current_app.api.save(
+            CreateSubmission(creator=user, client=client))
+        sid = submission.submission_id
+
+        current_app.api.save(
+            ProposeClassification(creator=user, client=client,
+                                  category="math.AG", is_primary=False,
+                                  comment="please reclassify"),
+            submission_id=sid,
+        )
+
+        assert len(service.sent) == 1
+        sent = service.last
+        # math.AG category-level + math archive-level moderators, no opt-outs.
+        assert sent.to == ["ag@example.org", "matharch@example.org"]
+        assert sent.reply_to == \
+            "MOD_ADMIN_EMAIL@example.org,ag@example.org,matharch@example.org"
+        assert sent.bcc == ["LOCAL_ADMIN_EMAIL@example.org"]
+        # Subject carries the submission id and submitter; the proposed
+        # category appears in the body (the subject shows current categories).
+        assert str(sid) in sent.subject
+        assert "Proposed: math.AG as secondary" in sent.body
+        # The submitter is never notified.
+        assert "cs@example.org" not in sent.to
+        assert "noweb@example.org" not in sent.to
+
+
+def test_system_proposal_sends_no_email(app, authorized_user):
+    """A system/classifier proposal does not email moderators."""
+    from submit_ce.domain.agent import System
+
+    with app.app_context():
+        user = authorized_user
+        client = InternalClient(name="test_proposal_email_sys")
+
+        service = current_app.api.email_service
+        service.clear()
+
+        submission, _ = current_app.api.save(
+            CreateSubmission(creator=user, client=client))
+        sid = submission.submission_id
+
+        current_app.api.save(
+            ProposeClassification(creator=System(name="classifier"),
+                                  category="math.AG", is_primary=False),
+            submission_id=sid,
+        )
+
+        assert service.sent == []

--- a/submit_ce/ui/tests/test_proposal_persistence.py
+++ b/submit_ce/ui/tests/test_proposal_persistence.py
@@ -1,0 +1,87 @@
+"""Persistence round-trip tests for category proposals.
+
+Verifies that :class:`.ProposeClassification` records a row in the classic
+``arXiv_submission_category_proposal`` table (with a linked admin-log comment)
+and that the proposal is read back onto the domain submission.
+"""
+
+from flask import current_app
+from arxiv.db import Session
+from sqlalchemy import text
+
+from submit_ce.domain.event import CreateSubmission, ProposeClassification
+from submit_ce.domain.agent import InternalClient
+
+
+def _create(user):
+    client = InternalClient(name="test_proposal_persist")
+    submission, _ = current_app.api.save(
+        CreateSubmission(creator=user, client=client))
+    return submission.submission_id, client
+
+
+def test_propose_primary_persists_classic_row(app, authorized_user):
+    """A primary proposal writes an UNRESOLVED row + admin-log comment."""
+    with app.app_context():
+        user = authorized_user
+        sid, client = _create(user)
+
+        submission, _ = current_app.api.save(
+            ProposeClassification(creator=user, client=client,
+                                  category="cs.AI", is_primary=True,
+                                  comment="please reclassify"),
+            submission_id=sid,
+        )
+
+        # Domain projection on the returned submission.
+        assert any(p.category == "cs.AI" and p.is_primary and p.is_unresolved
+                   for p in submission.proposals.values())
+
+        row = Session.execute(text("""
+            SELECT category, is_primary, proposal_status, user_id,
+                   proposal_comment_id, response_comment_id
+            FROM arXiv_submission_category_proposal
+            WHERE submission_id = :sid
+        """), {"sid": sid}).fetchone()
+        assert row is not None
+        assert row.category == "cs.AI"
+        assert row.is_primary == 1
+        assert row.proposal_status == 0      # UNRESOLVED
+        assert row.user_id is not None
+        assert row.response_comment_id is None
+        assert row.proposal_comment_id is not None
+
+        log_row = Session.execute(text("""
+            SELECT logtext FROM arXiv_admin_log WHERE id = :id
+        """), {"id": row.proposal_comment_id}).fetchone()
+        assert log_row is not None
+        assert "cs.AI" in log_row.logtext
+        assert "primary" in log_row.logtext
+
+        # Read-back via the API (to_submission).
+        reloaded = current_app.api.get(str(sid))
+        assert any(p.category == "cs.AI" and p.is_primary
+                   for p in reloaded.proposals.values())
+
+
+def test_propose_secondary_persists_is_primary_zero(app, authorized_user):
+    """A cross-list proposal is stored with is_primary = 0."""
+    with app.app_context():
+        user = authorized_user
+        sid, client = _create(user)
+
+        current_app.api.save(
+            ProposeClassification(creator=user, client=client,
+                                  category="math.CO", is_primary=False),
+            submission_id=sid,
+        )
+
+        row = Session.execute(text("""
+            SELECT category, is_primary, proposal_status
+            FROM arXiv_submission_category_proposal
+            WHERE submission_id = :sid
+        """), {"sid": sid}).fetchone()
+        assert row is not None
+        assert row.category == "math.CO"
+        assert row.is_primary == 0
+        assert row.proposal_status == 0


### PR DESCRIPTION
  SUBMISSION-174: Moderator notification emails

  Context

  arXiv's legacy system (arXiv::Submit::Email::*) emails category moderators at two points: when a
  classification is proposed and when a submission is finalized. Neither path existed in the event-sourced
  submit-ce domain. This PR ports both, along with the proposal/moderator domain models and persistence they
  require.

  What's included

  1. Proposal domain model + persistence
  - Proposal / ProposalStatus (domain/proposal.py), mirroring classic arXiv_submission_category_proposal.
  -  ProposeClassification event records a primary/cross-list proposal without changing categories; rejects
  duplicate unresolved proposals.
  - Submission.proposals dict; save/load wired through the legacy implementation (db.py, models.py).

  2. Moderator model + recipient resolution
  - Moderator domain type (domain/moderator.py), decoupled from SQLAlchemy.
  - SubmitApi.moderators_for_categories(categories, *, exclude_no_web_email, exclude_no_email,
  exclude_no_reply_to)   implemented in LegacySubmitImplementation, delegated in PubSub, stubbed in the null
  impl.
  - Recipient logic (legacy_implementation/moderators.py): for each category, unions category-level +
  archive-level (subject_class == '') moderators, applies opt-out flags, dedupes by email.

  3. Moderator email on classification proposal
  - EmailProposalModeratorsMsg (domain/event/email_mods.py), emitted as a consequence of ProposeClassification.
  - System/classifier proposals are silent; only moderator-made proposals send mail.

  4. Moderator email on finalize
  - EmailModeratorsFinalizeMsg (domain/event/email_mod_finalize.py), emitted as a consequence of
  FinalizeSubmission.
  - Type gating: sent only for new/rep/wdr/cross; jref and auto-held (e.g. oversize) submissions send
  no moderator email.
  - Header composition: fetches the full candidate set (no_web_email not excluded here, unlike the
  proposal email) and derives   To = moderators minus no_email (falls back to archival_email when empty);
  Reply-To = mod_reply_to_email + moderators minus no_reply_to; Bcc = archival_email, omitted on the fallback.
  - Per-type subjects/bodies with stable <submit.{id}@{site}> threading. Variables the model lacks
  yet (submitter_warnings, near_duplicates, real classifier abstract, genuinely "newly added" categories) are
  TODO placeholders, matching the existing submitter-email precedent.

  5. Config
  - SubmitConfig gains mod_reply_to_email, archival_email, and url_for_moderator_review (read from
  MOD_REPLY_TO_EMAIL / ARCHIVAL_EMAIL / URL_FOR_MODERATOR_REVIEW); placeholder defaults switched to
  @arxiv.example.com.

  Notes / known limitations

  - Sending is non-fatal for both emails  failures are recorded on event.error and never abort the save
  (matches legacy eval-wrapped sends).
  - "Relevant categories" uses primary + secondary (a safe superset) since the model has no per-category
  published flag yet; categories_to_email adds unresolved proposal categories. TODO to narrow once
  published-category tracking exists.
  - The Re:-on-resubmit subject prefix is deferred (resubmit state isn't tracked yet).

  Testing

  - New: test_email_mods.py, test_propose_classification.py, test_proposal_persistence.py, test_moderators.py,
  test_moderator_api.py, test_proposal_email.py, test_email_mod_finalize.py, plus gating tests in
  test_finalize_oversize_hold.py.
  - Updated the pinned FinalizeSubmission.CONSEQUENCE_TYPES assertion, the generic PubSub delegation test (now
  handles keyword-only params), and the submitter-email integration test (now filters the second email).
  - make_test_db.py seeds moderator/proposal fixtures.
  - Full suite: 455 passed, 55 skipped; ruff clean.