### PR TITLE
Fix BuildSourcePackage validation hook + oversize test fake (SUBMISSION-169)

### DIFF
--- a/submit_ce/domain/event/process.py
+++ b/submit_ce/domain/event/process.py
@@ -140,7 +140,7 @@ class BuildSourcePackage(EventWithSideEffect):
     NAME = "build source package"
     NAMED = "built source package"
 
-    def validate(self, submission: Submission) -> None:
+    def validate_pre_lock(self, submission: Submission) -> None:
         """The submission must exist to have a source package built."""
         if not submission.submission_id:
             raise InvalidEvent(

--- a/submit_ce/domain/event/tests/test_oversize_detection.py
+++ b/submit_ce/domain/event/tests/test_oversize_detection.py
@@ -50,7 +50,16 @@ class _FakeStore:
     def get_workspace(self, sid):
         return self.workspace
 
+    def delete_source_package(self, sid):
+        pass
+
     def delete_preflight(self, sid):
+        pass
+
+    def delete_user_decisions(self, sid):
+        pass
+
+    def delete_directives(self, sid):
         pass
 
     def delete_preview(self, sid):


### PR DESCRIPTION
Two integration breaks that surfaced once SUBMISSION-169, the oversize PR, and
the Event.validate() -> validate_pre_lock() rename all landed on develop:

- BuildSourcePackage still defined validate(), so after the rename the base
  validate_pre_lock() (which raises NotImplementedError) ran instead -- every
  Download-Source-Package request errored. Rename the hook to validate_pre_lock.
- _common_file_change_execute now calls delete_source_package (169), but the
  oversize tests' _FakeStore only stubbed delete_preflight/delete_preview.
  Add stubs for delete_source_package/user_decisions/directives.
  
  
  ```
...
  submit_ce/ui/workflow/processor.py                                   58      5     24      4    89%
submit_ce/ui/workflow/stages.py                                      89      0      6      1    99%
---------------------------------------------------------------------------------------------------
TOTAL                                                              6903   1205   2238    286    79%

Required test coverage of 70.0% reached. Total coverage: 79.24%
============================================== 411 passed, 55 skipped, 1 warning in 59.84s ===============================================

```
