### PR TITLE
SUBMISSION-158: check secondary

### DIFF
--- a/submit_ce/domain/event/__init__.py
+++ b/submit_ce/domain/event/__init__.py
@@ -1008,6 +1008,7 @@ class FinalizeSubmission(Event):
         if not submission.is_active:
             raise InvalidEvent(self, "Submission must be active")
         self._required_fields_are_complete(submission)
+        validators.no_secondaries_on_general_primary(self, submission)
 
     def project(self, submission: Submission) -> Submission:
         """Set :attr:`Submission.is_finalized`."""

--- a/submit_ce/domain/event/__init__.py
+++ b/submit_ce/domain/event/__init__.py
@@ -295,6 +295,7 @@ class SetPrimaryClassification(Event):
         self._must_be_unannounced(submission)
         validators.submission_is_not_finalized(self, submission)
         validators.cannot_be_secondary(self, self.category, submission)
+        validators.no_secondaries_on_general_primary(self, submission)
 
     def _must_be_unannounced(self, submission: Submission) -> None:
         """Can only be set on the first version before publication."""
@@ -344,6 +345,7 @@ class AddSecondaryClassification(Event):
         validators.no_redundant_general_category(self, self.category, submission)
         validators.no_redundant_non_general_category(self, self.category, submission)
         validators.cannot_be_genph(self, self.category, submission)
+        validators.no_secondary_when_primary_general(self, submission)
 
     def project(self, submission: Submission) -> Submission:
         """Add a :class:`.Classification` as a secondary classification."""

--- a/submit_ce/domain/event/tests/test_general_primary_no_secondaries.py
+++ b/submit_ce/domain/event/tests/test_general_primary_no_secondaries.py
@@ -12,7 +12,13 @@ import pytest
 
 from submit_ce.domain import agent, meta
 from submit_ce.domain.uploads import SourceFormat
-from submit_ce.domain.event import FinalizeSubmission, InvalidEvent
+from submit_ce.domain.event import (
+    AddSecondaryClassification,
+    FinalizeSubmission,
+    InvalidEvent,
+    RemoveSecondaryClassification,
+    SetPrimaryClassification,
+)
 from submit_ce.domain.submission import Submission, SubmissionMetadata
 
 GENERAL_PRIMARY = "math.GM"      # is_general == True
@@ -84,3 +90,99 @@ def test_new_submission_general_primary_with_secondary_still_blocked():
     sub = _finalizable(GENERAL_PRIMARY, [SECONDARY], version=1)
     with pytest.raises(InvalidEvent, match="general primary category"):
         _finalize().validate_pre_lock(sub)
+
+
+# ---------------------------------------------------------------------------
+# The same check also runs on SetPrimaryClassification and
+# AddSecondaryClassification, so the invalid combination is caught as the user
+# builds it, not only at finalize. These tests exercise those two call sites
+# and confirm the user cannot get stuck.
+# ---------------------------------------------------------------------------
+
+# Endorsed for everything so SetPrimaryClassification's endorsement check passes
+# and we isolate the general-primary rule.
+_USER = agent.PublicUser(name="Endorsed User", user_id="u2",
+                         email="u2@example.org", endorsements=["*.*"])
+
+
+def _sub(primary=None, secondaries=(), version=1):
+    return Submission(
+        creator=_USER, owner=_USER, created=_now(), version=version,
+        primary_classification=meta.Classification(primary) if primary else None,
+        secondary_classification=[meta.Classification(c) for c in secondaries])
+
+
+def _set_primary(cat):
+    return SetPrimaryClassification(creator=_USER, created=_now(), category=cat)
+
+
+def _add_secondary(cat):
+    return AddSecondaryClassification(creator=_USER, created=_now(), category=cat)
+
+
+def _remove_secondary(cat):
+    return RemoveSecondaryClassification(creator=_USER, created=_now(), category=cat)
+
+
+# --- SetPrimaryClassification ---
+
+def test_set_primary_general_with_no_secondaries_ok():
+    """The common path: choosing a general primary on a submission with no
+    secondaries is allowed, so the user is not blocked."""
+    _set_primary(GENERAL_PRIMARY).validate_pre_lock(_sub())  # no raise
+
+
+def test_set_primary_rejected_when_current_general_primary_has_secondary():
+    """The check runs on SetPrimaryClassification: a submission that already
+    carries a general primary with a secondary is rejected."""
+    with pytest.raises(InvalidEvent, match="general primary category"):
+        _set_primary(SPECIFIC_PRIMARY).validate_pre_lock(
+            _sub(GENERAL_PRIMARY, [SECONDARY]))
+
+
+def test_set_primary_toward_general_with_specific_current_ok():
+    """Switching a *specific* primary (that has a secondary) toward a general
+    one is not blocked by this event -- the check reads the current primary,
+    which is still specific. The controller drops the secondary on save."""
+    _set_primary(GENERAL_PRIMARY).validate_pre_lock(
+        _sub(SPECIFIC_PRIMARY, [SECONDARY]))  # no raise
+
+
+# --- AddSecondaryClassification ---
+
+def test_add_first_secondary_to_general_primary_rejected():
+    """The tightened check rejects even the first secondary added under a
+    general primary (the add is blocked based on the primary alone)."""
+    with pytest.raises(InvalidEvent, match="cross-list category may not be added"):
+        _add_secondary(SECONDARY).validate_pre_lock(_sub(GENERAL_PRIMARY, []))
+
+
+def test_add_secondary_rejected_when_general_primary_has_secondary():
+    """Adding another secondary when a general primary already has one is
+    also rejected."""
+    with pytest.raises(InvalidEvent, match="cross-list category may not be added"):
+        _add_secondary("cs.AI").validate_pre_lock(
+            _sub(GENERAL_PRIMARY, [SECONDARY]))
+
+
+def test_add_secondary_ok_when_primary_is_specific():
+    _add_secondary(SECONDARY).validate_pre_lock(_sub(SPECIFIC_PRIMARY))  # no raise
+
+
+def test_add_secondary_replacement_is_exempt():
+    """version > 1 is exempt (edge case 1)."""
+    _add_secondary("cs.AI").validate_pre_lock(
+        _sub(GENERAL_PRIMARY, [SECONDARY], version=2))  # no raise
+
+
+# --- not stuck ---
+
+def test_not_stuck_can_recover_from_general_primary_with_secondary():
+    """A submission that somehow holds a general primary with a secondary is
+    recoverable: removing the secondary is not blocked, and the primary can
+    then be changed. The user is never trapped."""
+    stuck = _sub(GENERAL_PRIMARY, [SECONDARY])
+    after_remove = _remove_secondary(SECONDARY).apply(stuck)
+    assert after_remove.secondary_categories == []
+    # With the secondary gone, changing the primary is allowed again.
+    _set_primary(SPECIFIC_PRIMARY).validate_pre_lock(after_remove)  # no raise

--- a/submit_ce/domain/event/tests/test_general_primary_no_secondaries.py
+++ b/submit_ce/domain/event/tests/test_general_primary_no_secondaries.py
@@ -1,0 +1,69 @@
+"""SUBMISSION-158: a submission with a general primary category may not carry
+any secondary classifications. Enforced at finalize (every submission).
+
+Edge cases (replacement-inherited and moderator/EUST-added secondaries) are
+deferred to a follow-up and are not covered here.
+"""
+
+from datetime import datetime
+
+from pytz import UTC
+import pytest
+
+from submit_ce.domain import agent, meta
+from submit_ce.domain.uploads import SourceFormat
+from submit_ce.domain.event import FinalizeSubmission, InvalidEvent
+from submit_ce.domain.submission import Submission, SubmissionMetadata
+
+GENERAL_PRIMARY = "math.GM"      # is_general == True
+SPECIFIC_PRIMARY = "astro-ph.GA"  # is_general == False
+SECONDARY = "astro-ph.CO"
+
+
+def _now():
+    return datetime.now(UTC)
+
+
+def _user():
+    return agent.PublicUser(name="Test User", user_id="u1",
+                            email="u1@example.org", endorsements=[])
+
+
+def _finalizable(primary, secondaries):
+    """An otherwise-finalizable submission with the given primary and
+    secondary categories, so finalize can fail only on this rule."""
+    u = _user()
+    return Submission(
+        creator=u, owner=u, created=_now(),
+        source_format=SourceFormat("pdf"),
+        license=meta.License(uri="http://free", name="free"),
+        submitter_accepts_policy=True,
+        primary_classification=meta.Classification(primary),
+        secondary_classification=[meta.Classification(c) for c in secondaries],
+        metadata=SubmissionMetadata(
+            title="the best title",
+            abstract="very abstract",
+            authors_display="J K Jones, F W Englund",
+        ),
+    )
+
+
+def _finalize():
+    return FinalizeSubmission(creator=_user(), created=_now())
+
+
+def test_general_primary_with_secondary_cannot_finalize():
+    sub = _finalizable(GENERAL_PRIMARY, [SECONDARY])
+    with pytest.raises(InvalidEvent, match="general primary category"):
+        _finalize().validate_pre_lock(sub)
+
+
+def test_general_primary_without_secondary_can_finalize():
+    sub = _finalizable(GENERAL_PRIMARY, [])
+    _finalize().validate_pre_lock(sub)  # does not raise
+
+
+def test_specific_primary_with_secondary_can_finalize():
+    """The rule only applies to general primaries."""
+    sub = _finalizable(SPECIFIC_PRIMARY, [SECONDARY])
+    _finalize().validate_pre_lock(sub)  # does not raise

--- a/submit_ce/domain/event/tests/test_general_primary_no_secondaries.py
+++ b/submit_ce/domain/event/tests/test_general_primary_no_secondaries.py
@@ -29,12 +29,13 @@ def _user():
                             email="u1@example.org", endorsements=[])
 
 
-def _finalizable(primary, secondaries):
+def _finalizable(primary, secondaries, version=1):
     """An otherwise-finalizable submission with the given primary and
     secondary categories, so finalize can fail only on this rule."""
     u = _user()
     return Submission(
         creator=u, owner=u, created=_now(),
+        version=version,
         source_format=SourceFormat("pdf"),
         license=meta.License(uri="http://free", name="free"),
         submitter_accepts_policy=True,
@@ -67,3 +68,19 @@ def test_specific_primary_with_secondary_can_finalize():
     """The rule only applies to general primaries."""
     sub = _finalizable(SPECIFIC_PRIMARY, [SECONDARY])
     _finalize().validate_pre_lock(sub)  # does not raise
+
+
+def test_replacement_general_primary_with_inherited_secondary_can_finalize():
+    """SUBMISSION-158 edge case 1: a replacement (version > 1) inherits its
+    categories from the announced version and cannot change them, so a general
+    primary with (grandfathered) secondaries must not block the replacement."""
+    sub = _finalizable(GENERAL_PRIMARY, [SECONDARY], version=2)
+    _finalize().validate_pre_lock(sub)  # does not raise
+
+
+def test_new_submission_general_primary_with_secondary_still_blocked():
+    """The exemption is only for replacements; a first-version submission with
+    a general primary and a secondary is still blocked."""
+    sub = _finalizable(GENERAL_PRIMARY, [SECONDARY], version=1)
+    with pytest.raises(InvalidEvent, match="general primary category"):
+        _finalize().validate_pre_lock(sub)

--- a/submit_ce/domain/event/validators.py
+++ b/submit_ce/domain/event/validators.py
@@ -153,6 +153,31 @@ def no_secondaries_on_general_primary(event: Event,
             "categories.")
 
 
+def no_secondary_when_primary_general(event: Event,
+                                      submission: Submission) -> None:
+    """A cross-list (secondary) may not be *added* when the primary category
+    is general (SUBMISSION-158).
+
+    Unlike :func:`no_secondaries_on_general_primary`, which looks at
+    secondaries already present, this rejects the add itself based only on the
+    primary. It is used by :class:`.AddSecondaryClassification` so that even
+    the first secondary under a general primary is blocked (the event runs
+    before its own projection, so the secondary being added is not yet on the
+    submission).
+
+    Replacements (``version > 1``) are exempt for the same reason as
+    :func:`no_secondaries_on_general_primary`.
+    """
+    if submission.version > 1:
+        return
+    if (submission.primary_classification
+            and CATEGORIES[submission.primary_category].is_general):
+        raise InvalidEvent(
+            event,
+            "A cross-list category may not be added when the primary "
+            f"category ({submission.primary_category}) is general.")
+
+
 def max_secondaries(event: Event, submission: Submission) -> None:
     "No more than 4 secondary categories per submission."
     if (submission.secondary_classification and

--- a/submit_ce/domain/event/validators.py
+++ b/submit_ce/domain/event/validators.py
@@ -120,6 +120,30 @@ def no_redundant_non_general_category(event: Event,
                                f' to general secondaries.')
 
 
+def no_secondaries_on_general_primary(event: Event,
+                                      submission: Submission) -> None:
+    """A submission with a general primary category may not carry any
+    secondary classifications (SUBMISSION-158).
+
+    Checked at finalize so it runs on every submission. Unlike
+    :func:`no_redundant_non_general_category` (add-time, same-archive only),
+    this rejects *any* secondary under a general primary.
+
+    TODO(SUBMISSION-158): the replacement / moderator-added edge cases are not
+    yet handled here. Exempting secondaries inherited from a prior announced
+    version or added by moderators/EUST needs ``Submission.versions`` or
+    classification provenance, neither of which exists yet.
+    """
+    if (submission.primary_classification
+            and CATEGORIES[submission.primary_category].is_general
+            and submission.secondary_classification):
+        raise InvalidEvent(
+            event,
+            "A submission with a general primary category "
+            f"({submission.primary_category}) may not have secondary "
+            "categories.")
+
+
 def max_secondaries(event: Event, submission: Submission) -> None:
     "No more than 4 secondary categories per submission."
     if (submission.secondary_classification and

--- a/submit_ce/domain/event/validators.py
+++ b/submit_ce/domain/event/validators.py
@@ -125,15 +125,24 @@ def no_secondaries_on_general_primary(event: Event,
     """A submission with a general primary category may not carry any
     secondary classifications (SUBMISSION-158).
 
-    Checked at finalize so it runs on every submission. Unlike
-    :func:`no_redundant_non_general_category` (add-time, same-archive only),
-    this rejects *any* secondary under a general primary.
+    Checked at finalize. Unlike :func:`no_redundant_non_general_category`
+    (add-time, same-archive only), this rejects *any* secondary under a
+    general primary.
 
-    TODO(SUBMISSION-158): the replacement / moderator-added edge cases are not
-    yet handled here. Exempting secondaries inherited from a prior announced
-    version or added by moderators/EUST needs ``Submission.versions`` or
-    classification provenance, neither of which exists yet.
+    Only enforced for first-version (new) submissions. Replacements
+    (``version > 1``) are exempt: the replacement workflow has no
+    classification stage and the primary is locked once announced
+    (see ``SetPrimaryClassification._must_be_unannounced``), so every category
+    on a replacement is inherited from the announced version. A general
+    primary with secondaries there was grandfathered in and must not block the
+    replacement (SUBMISSION-158 edge case 1).
+
+    TODO(SUBMISSION-158 edge case 2): a moderator/EUST-added secondary on the
+    *working* version still can't be distinguished from a submitter-added one
+    without classification provenance, which does not exist yet.
     """
+    if submission.version > 1:
+        return
     if (submission.primary_classification
             and CATEGORIES[submission.primary_category].is_general
             and submission.secondary_classification):

--- a/submit_ce/implementations/legacy_implementation/models.py
+++ b/submit_ce/implementations/legacy_implementation/models.py
@@ -449,7 +449,8 @@ class Submission(Base):    # type: ignore
             self.categories.remove(cur_primary)
             self.categories.append(
                 SubmissionCategory(submission_id=self.submission_id,
-                                   category=primary_category)
+                                   category=primary_category,
+                                   is_primary=1)
             )
         elif cur_primary is None and primary_category:
             self.categories.append(

--- a/submit_ce/ui/controllers/new/classification.py
+++ b/submit_ce/ui/controllers/new/classification.py
@@ -39,6 +39,7 @@ from http import HTTPStatus as status
 from typing import Optional, Tuple, Dict, Any
 
 from arxiv import taxonomy
+from arxiv.base import alerts
 from arxiv.auth.domain import Session
 from arxiv.forms import csrf
 from arxiv.taxonomy.category import Category
@@ -268,15 +269,35 @@ def classification(
             form.mutate_stage_secondary_remove(cat, submission)
             return stay_on_this_stage((response_data, status.OK, {}))
         case "next":  # green "save&continue" button
+            staged_add = list(form.secondaries_staged_add.data or [])
+            staged_remove = list(form.secondaries_staged_remove.data or [])
+
+            # SUBMISSION-158: a general primary category may not carry any
+            # secondaries. If the primary being saved is general, drop the
+            # cross-lists for the user and keep them on this page with a
+            # message, rather than letting an invalid combination proceed or
+            # leaving orphaned secondaries in storage.
+            new_primary = form.primary.data or primary_cat_id
+            new_primary_cat = _cat(new_primary)
+            drop_for_general = False
+            if new_primary_cat and new_primary_cat.is_general:
+                effective_secondaries = (
+                    (set(submission.secondary_categories) | set(staged_add))
+                    - set(staged_remove))
+                if effective_secondaries:
+                    staged_add = []
+                    staged_remove = sorted(set(submission.secondary_categories))
+                    drop_for_general = True
+
             commands = []
-            for sec_rm in form.secondaries_staged_remove.data or []:
+            for sec_rm in staged_remove:
                 commands.append(RemoveSecondaryClassification(
                     category=sec_rm,
                     creator=submitter,
                     client=client,
                 ))
 
-            for sec_add in form.secondaries_staged_add.data:
+            for sec_add in staged_add:
                 commands.append(AddSecondaryClassification(
                     category=sec_add,
                     creator=submitter,
@@ -299,6 +320,20 @@ def classification(
 
             submission, _ = current_app.api.save(*commands, submission_id=submission_id)
             response_data["submission"] = submission
+            response_data["primary"] = _cat(submission.primary_classification)
+            response_data["primary_is_general"] = bool(
+                response_data["primary"] and response_data["primary"].is_general)
+
+            if drop_for_general:
+                form.secondaries_staged_add.data = set()
+                form.secondaries_staged_remove.data = set()
+                alerts.flash_warning(
+                    "Cross-list categories are not allowed with a general "
+                    "primary category. Your cross-list selections have been "
+                    "removed. Choose a non-general primary category if you "
+                    "need cross-lists.")
+                return stay_on_this_stage((response_data, status.OK, {}))
+
             return ready_for_next((response_data, status.OK, {}))
         case _:  # Primary selection change
             form.mutate_primary_change(submission)

--- a/submit_ce/ui/controllers/new/classification.py
+++ b/submit_ce/ui/controllers/new/classification.py
@@ -243,6 +243,7 @@ def classification(
         "client": client,
         "form": form,
         "primary": primary,
+        "primary_is_general": bool(primary and primary.is_general),
     }
 
     if method == "GET":

--- a/submit_ce/ui/controllers/new/tests/test_classification.py
+++ b/submit_ce/ui/controllers/new/tests/test_classification.py
@@ -48,3 +48,13 @@ def test_primary_classification(app, authorized_client, sub_license):
     assert resp.status_code == 303 and "file_upload" in resp.headers["Location"]
     assert gets(app,sub).primary_classification and gets(app,sub).primary_classification.id == "astro-ph.CO"
     assert gets(app,sub).secondary_classification and gets(app,sub).secondary_classification[0].id == "astro-ph.GA"
+
+
+def test_crosslist_offered_for_non_general_primary(app, authorized_client, sub_primary):
+    """SUBMISSION-158 UI gate: a non-general primary (astro-ph.GA) still offers
+    cross-lists. The 'not available' note must not appear."""
+    sub = sub_primary
+    resp = authorized_client.get(f"/{sub.submission_id}/classification")
+    assert resp.status_code == 200
+    assert b'id="combobox"' in resp.data
+    assert b"not available because the primary category" not in resp.data

--- a/submit_ce/ui/controllers/new/tests/test_classification.py
+++ b/submit_ce/ui/controllers/new/tests/test_classification.py
@@ -88,6 +88,49 @@ def test_change_general_primary_to_specific(app, authorized_client, authorized_u
     assert gets(app, sub).primary_classification.id == "cs.HC"
 
 
+def test_general_primary_drops_secondary_and_stays(app, authorized_client, authorized_user, sub_license):
+    """SUBMISSION-158: saving primary=cs.HC + secondary=cs.DB, then changing
+    the primary to a general category (cs.OH), must NOT advance to upload with
+    the secondary intact. The secondary is dropped and the user stays on the
+    classification page; switching back to cs.HC does not bring cs.DB back."""
+    sub = sub_license
+    _endorse(app, authorized_user, "cs.OH", "cs.HC", "cs.DB")
+    url = f"/{sub.submission_id}/classification"
+
+    # Save a non-general primary with a secondary.
+    resp = authorized_client.get(url)
+    resp = authorized_client.post(url, data={'csrf_token': parse_csrf_token(resp),
+                                             'primary': 'cs.HC',
+                                             'secondaries_staged_add': 'cs.DB',
+                                             'action': 'next'})
+    assert resp.status_code == 303
+    saved = gets(app, sub)
+    assert saved.primary_classification.id == "cs.HC"
+    assert saved.secondary_categories == ["cs.DB"]
+
+    # Change primary to a general category: must stay on classification (200,
+    # not a 303 to file_upload) and drop the secondary.
+    resp = authorized_client.get(url)
+    resp = authorized_client.post(url, data={'csrf_token': parse_csrf_token(resp),
+                                             'primary': 'cs.OH',
+                                             'action': 'next'})
+    assert resp.status_code == 200
+    assert b"not allowed with a general" in resp.data
+    saved = gets(app, sub)
+    assert saved.primary_classification.id == "cs.OH"
+    assert saved.secondary_categories == []
+
+    # Switching the primary back to cs.HC must not resurrect cs.DB.
+    resp = authorized_client.get(url)
+    resp = authorized_client.post(url, data={'csrf_token': parse_csrf_token(resp),
+                                             'primary': 'cs.HC',
+                                             'action': 'next'})
+    assert resp.status_code == 303
+    saved = gets(app, sub)
+    assert saved.primary_classification.id == "cs.HC"
+    assert saved.secondary_categories == []
+
+
 def test_crosslist_offered_for_non_general_primary(app, authorized_client, sub_primary):
     """SUBMISSION-158 UI gate: a non-general primary (astro-ph.GA) still offers
     cross-lists. The 'not available' note must not appear."""

--- a/submit_ce/ui/controllers/new/tests/test_classification.py
+++ b/submit_ce/ui/controllers/new/tests/test_classification.py
@@ -131,6 +131,21 @@ def test_general_primary_drops_secondary_and_stays(app, authorized_client, autho
     assert saved.secondary_categories == []
 
 
+def test_general_primary_no_secondary_advances(app, authorized_client, authorized_user, sub_license):
+    """Not stuck: choosing a general primary (with no cross-lists) saves and
+    advances past the classification stage."""
+    sub = sub_license
+    _endorse(app, authorized_user, "math.GM")
+    url = f"/{sub.submission_id}/classification"
+    resp = authorized_client.get(url)
+    resp = authorized_client.post(url, data={'csrf_token': parse_csrf_token(resp),
+                                             'primary': 'math.GM',
+                                             'action': 'next'})
+    assert resp.status_code == 303, resp.data
+    assert "file_upload" in resp.headers["Location"]
+    assert gets(app, sub).primary_classification.id == "math.GM"
+
+
 def test_crosslist_offered_for_non_general_primary(app, authorized_client, sub_primary):
     """SUBMISSION-158 UI gate: a non-general primary (astro-ph.GA) still offers
     cross-lists. The 'not available' note must not appear."""

--- a/submit_ce/ui/controllers/new/tests/test_classification.py
+++ b/submit_ce/ui/controllers/new/tests/test_classification.py
@@ -1,8 +1,23 @@
 """Tests for :mod:`submit_ce.controllers.classification`."""
 
+import arxiv.db.models as classic
+from arxiv.db import Session
+
 from submit_ce.domain.submission import Submission
 from submit_ce.ui.tests import gets
 from submit_ce.ui.tests.csrf_util import parse_csrf_token
+
+
+def _endorse(app, user, *categories):
+    """Add auto endorsements so the fixture user can pick these categories."""
+    with app.app_context():
+        for cat in categories:
+            archive, _, subject = cat.partition(".")
+            Session.add(classic.Endorsement(
+                endorsee_id=user.user_id, archive=archive, subject_class=subject,
+                flag_valid=1, type="auto", point_value=10,
+                issued_when=11074371513))
+        Session.commit()
 
 
 primary_page_title=b"Suggest Category"
@@ -48,6 +63,29 @@ def test_primary_classification(app, authorized_client, sub_license):
     assert resp.status_code == 303 and "file_upload" in resp.headers["Location"]
     assert gets(app,sub).primary_classification and gets(app,sub).primary_classification.id == "astro-ph.CO"
     assert gets(app,sub).secondary_classification and gets(app,sub).secondary_classification[0].id == "astro-ph.GA"
+
+
+def test_change_general_primary_to_specific(app, authorized_client, authorized_user, sub_license):
+    """SUBMISSION-158 regression: after saving a general primary (cs.OH),
+    changing it to a non-general primary (cs.HC) must save and advance,
+    not lose the value and bounce back to the classification stage."""
+    sub = sub_license
+    _endorse(app, authorized_user, "cs.OH", "cs.HC")
+    url = f"/{sub.submission_id}/classification"
+
+    # Save a general primary.
+    resp = authorized_client.get(url)
+    resp = authorized_client.post(url, data={'csrf_token': parse_csrf_token(resp),
+                                             'primary': 'cs.OH', 'action': 'next'})
+    assert resp.status_code == 303
+    assert gets(app, sub).primary_classification.id == "cs.OH"
+
+    # Change it to a non-general primary and continue.
+    resp = authorized_client.get(url)
+    resp = authorized_client.post(url, data={'csrf_token': parse_csrf_token(resp),
+                                             'primary': 'cs.HC', 'action': 'next'})
+    assert resp.status_code == 303, resp.data
+    assert gets(app, sub).primary_classification.id == "cs.HC"
 
 
 def test_crosslist_offered_for_non_general_primary(app, authorized_client, sub_primary):

--- a/submit_ce/ui/templates/submit/classification.html
+++ b/submit_ce/ui/templates/submit/classification.html
@@ -74,6 +74,17 @@
     {% endwith %}
 
     {# CROSS-LIST CATEGORIES #}
+    {# SUBMISSION-158: a general primary category may not carry secondaries,
+       so don't offer cross-lists when the primary is general. #}
+    {% if primary_is_general %}
+    <div class="field secondary-container">
+      <label class="label" id="crosslist">Cross-list Category Suggestion (Optional)</label>
+      <div class="category-selection-container">
+        <p>Cross-list categories are not available because the primary category
+        is a general category.</p>
+      </div>
+    </div>
+    {% else %}
     {% set displayed_secondaries = form.secondaries_save_and_staged(submission, submitter) %}
     {% set saved_categories = submission.secondary_categories|list %}
     <div class="field secondary-container">
@@ -125,5 +136,6 @@
         </noscript>
       </div>
     </div>
+    {% endif %}
   </form>
 {% endblock within_content %}


### PR DESCRIPTION
- blocks a general primary with secondaries
- fix a missing is_primary=1
- replacements don't have a classification phase, and are skipped by the validation
- handle's edge2 for replacements, as classification is skipped.

- not done: allow eust to break the no-secondary rule for new submissions and then send back to the user for further edits.