### PR TITLE
SUBMISSION-207: Reset is_source_processed and clear preview on file change.

### DIFF
--- a/submit_ce/domain/event/file.py
+++ b/submit_ce/domain/event/file.py
@@ -17,8 +17,22 @@ import logging
 logger = logging.getLogger(__name__)
 
 def _common_file_change_project(submission: Submission) -> None:
-    """Common changes during `project` to submission when any file change happens."""
+    """Common state changes during `project` when any file change happens.
+
+    A file change invalidates the previous processing outcome: the compiled
+    preview no longer reflects the current source (its file and the compile log
+    are removed in `_common_file_change_execute`). So we mark the submission
+    unprocessed -- `is_source_processed=False`, which round-trips to the legacy
+    `must_process=1` column -- and drop the now-stale `submission.preview`,
+    mirroring `UnConfirmSourceProcessed`. Without this the Process stage stays
+    "complete" after an edit (letting the submitter skip recompilation) and
+    `submission.preview` dangles at a deleted file. Applies to both TeX and
+    PDF-only submissions, since all file-change events route through here.
+    [SUBMISSION-207]
+    """
     submission.submitter_confirmed_preview = False
+    submission.is_source_processed = False
+    submission.preview = None
 
 
 def _common_file_change_execute(api: SubmitApi, submission: Submission) -> None:

--- a/submit_ce/domain/event/tests/test_file_events.py
+++ b/submit_ce/domain/event/tests/test_file_events.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pytz import UTC
 
 from submit_ce.domain import submission as submod, agent
+from submit_ce.domain.preview import Preview
 from submit_ce.domain.event.file import (
     UploadFiles, RemoveFiles, RemoveAllFiles, _common_file_change_execute,
 )
@@ -60,6 +61,42 @@ def test_remove_all_files_clears_package():
 
     assert s.source_format is None
     assert s.uncompressed_size == 0
+    assert s.submitter_confirmed_preview is False
+
+
+def _processed_submission():
+    """A submission that has already been processed, with a preview recorded."""
+    s = _blank_submission()
+    s.is_source_processed = True
+    s.submitter_confirmed_preview = True
+    s.preview = Preview(source_id=1, source_checksum="a",
+                        preview_checksum="b", size_bytes=10, added=_now())
+    return s
+
+
+def test_upload_resets_processing_state():
+    """Uploading files after a submission is processed marks it unprocessed and
+    drops the stale preview, so Process re-runs on the new source. [SUBMISSION-207]"""
+    s = _processed_submission()
+    e = UploadFiles(creator=s.creator, files=[])
+    e.validate_pre_lock(s)
+    s = e.project(s)
+
+    assert s.is_source_processed is False
+    assert s.preview is None
+    assert s.submitter_confirmed_preview is False
+
+
+def test_remove_all_resets_processing_state():
+    """RemoveAllFiles (e.g. swapping a processed PDF-only submission's file) also
+    resets the processing state and clears the preview. [SUBMISSION-207]"""
+    s = _processed_submission()
+    e = RemoveAllFiles(creator=s.creator)
+    e.validate_pre_lock(s)
+    s = e.project(s)
+
+    assert s.is_source_processed is False
+    assert s.preview is None
     assert s.submitter_confirmed_preview is False
 
 


### PR DESCRIPTION
Summary. After a submission was processed, editing its files left it incorrectly marked as "processed," so the workflow could skip recompiling the changed source and could reference a stale preview. This resets the processing state on any file change, forcing reprocessing of the new source — for both TeX and PDF-only submissions.

Problem. The file-change events (UploadFiles, UploadArchive, RemoveFiles, RemoveAllFiles) delete the derived artifacts (preview, compile log, preflight, directives, source package) but never reset the submission's processing state. So after a submission is processed (is_source_processed=True), editing files left it wrongly marked processed:

legacy must_process stayed 0 ("already processed");
the Process stage's completion gate (conditions.is_source_processed) stayed satisfied, letting the workflow skip recompilation of the changed source;
submission.preview dangled at a now-deleted preview file (which ConfirmPreview.validate later checksum-matches).

This affected both TeX and PDF-only submissions, which route through the same _common_file_change_* helpers.
Fix. Extend the shared _common_file_change_project(submission) helper — already called by all four file-change events' project() — to also set is_source_processed=False and preview=None, mirroring UnConfirmSourceProcessed. Because is_source_processed round-trips to the legacy must_process column, must_process correctly returns to 1 after any file change.
Tests. Added test_upload_resets_processing_state and test_remove_all_resets_processing_state: a processed submission (is_source_processed=True, preview set) has both reset after an upload or remove-all.

