### PR TITLE
SUBMISSION-123: Replace placeholder submission agreement with final approved text 

### DIFF
--- a/submit_ce/ui/templates/submit/policy.html
+++ b/submit_ce/ui/templates/submit/policy.html
@@ -5,7 +5,7 @@
 
 {% block within_content %}
 
-<h2>Read and accept the Submission Agreement before proceeding</h2>
+<h2>Scroll to read and accept the arXiv Submission Agreement before proceeding</h2>
 
 <form id="form" method="POST" action="{{ url_for('ui.policy', submission_id=submission_id) }}">
 
@@ -16,17 +16,171 @@
         <div class="policy-scroll" style="max-height:300px;">
             <h3>arXiv Submission Agreement</h3>
 
-            <p>Submission agreement content goes here. Submission agreement content goes here. Submission agreement
-                content goes here. <p>Submission agreement content goes here. Submission agreement content goes here.
-                Submission agreement content goes here. Submission agreement content goes here. Submission agreement
-                content goes here. <p>Submission agreement content goes here. Submission agreement content goes here.
-                Submission agreement content goes here. Submission agreement content goes here. Submission agreement
-                content goes here. <p>Submission agreement content goes here. Submission agreement content goes here.
-                Submission agreement content goes here. Submission agreement content goes here. Submission agreement
-                content goes here. <p>Submission agreement content goes here. Submission agreement content goes here.
-                Submission agreement content goes here. Submission agreement content goes here. Submission agreement
-                content goes here. <p>Submission agreement content goes here. Submission agreement content goes here.
-                Submission agreement content goes here. </p>
+            <p>arXiv is a curated research-sharing platform emphasizing openness, collaboration, and scholarship.
+                By submitting content and/or metadata (the &ldquo;Work&rdquo;), you (including any other authors of the
+                Work) are agreeing to comply with these terms, which is an agreement (the &ldquo;Agreement&rdquo;)
+                between you and arXiv, Inc. (&ldquo;arXiv&rdquo;). Metadata includes title, author, abstract, and other
+                information describing the Work.</p>
+
+            <h4>Representations and Warranties</h4>
+
+            <p>I make the following representations and warranties:</p>
+
+            <ul>
+                <li>I am the original author of the Work or a proxy pre-approved by arXiv acting on behalf of an
+                    original author.</li>
+                <li>I am completing this Agreement on behalf of and binding all author(s).</li>
+                <li>I have full authority to enter into and make this Agreement, to grant the rights contained in this
+                    Agreement, and to take the other actions described herein. If the Work was created by multiple
+                    authors, I affirm that my co-author(s) have consented to the submission of the Work to arXiv,
+                    including my entering into this Agreement on their behalf.</li>
+                <li>I have the right to include any third-party materials used in the Work, and confirm that their use
+                    is consistent with scholarly and academic standards of proper citation and acknowledgement of
+                    sources.</li>
+                <li>The Work is not subject to any agreement, license, or other claim that could interfere with the
+                    rights granted to arXiv herein, and the distribution of the Work by arXiv will not violate the
+                    rights of any person or entity, including, without limitation, any rights of copyright, patent,
+                    trade secret, or privacy.</li>
+                <li>The Work contains no defamatory, obscene, or other unlawful matter.</li>
+                <li>I have read the <a href="https://info.arxiv.org/help/policies/privacy_policy.html"
+                    target="_blank" rel="noopener">arXiv privacy policy</a>, and understand and agree that, if accepted
+                    by arXiv, the Work (including any personal data therein) will be permanently preserved online, where
+                    it may be viewed and downloaded by anyone, for the purpose of achieving arXiv&rsquo;s mission of
+                    research and archiving in the public interest.</li>
+                <li>I will not enter into other agreements or make other commitments that would conflict with the
+                    rights granted to arXiv.</li>
+            </ul>
+
+            <h4>Acceptance of and Compliance with arXiv Policies</h4>
+
+            <p>I accept and agree to comply with all arXiv policies, including but not limited to, those related to the
+                <a href="https://info.arxiv.org/help/policies/code_of_conduct.html" target="_blank" rel="noopener">code
+                of conduct</a>, <a href="https://info.arxiv.org/help/moderation/index.html" target="_blank"
+                rel="noopener">moderation</a>, and <a href="https://info.arxiv.org/help/policies/privacy_policy.html"
+                target="_blank" rel="noopener">privacy</a>. It is my responsibility to periodically review arXiv
+                policies, as these policies may change from time to time. My failure to comply with applicable policies
+                may result in arXiv suspending access, removing Works, or otherwise taking action it determines is
+                necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any
+                action in furtherance of applicable laws or arXiv policies, including but not limited to removal of a
+                Work or blocking access to it.</p>
+
+            <h4>Curation of Content</h4>
+
+            <p>arXiv is a moderated repository for scholarly material, and, as such, maintains a permanent collection
+                of submitted Works. arXiv maintains a permanent record of all versions of Works that are submitted,
+                including previous versions that have been updated and/or corrected. By making this submission to
+                arXiv, I agree to the following:</p>
+
+            <ul>
+                <li>arXiv reserves, in its sole discretion, the right to reclassify, reject, or remove any
+                    submission.</li>
+                <li>Submitted Work will be automatically compared with other Work submitted to arXiv, and any detected
+                    text overlap may be noted by arXiv in the metadata.</li>
+                <li>In cases where a Work is found to violate arXiv policy, arXiv may remove or withdraw the Work.</li>
+                <li>arXiv may indicate concerns about the Work in the Comments metadata as part of the permanent
+                    record.</li>
+                <li>Metadata may be corrected to conform to arXiv standards.</li>
+            </ul>
+
+            <h4>Grant of License to arXiv</h4>
+
+            <p>By making this submission to arXiv:</p>
+
+            <ul>
+                <li>I grant arXiv a non-exclusive, perpetual, irrevocable, worldwide, and royalty-free license to
+                    include the Work in the arXiv repository.</li>
+                <li>I permit users to access, view, and make other uses of the Work in a manner consistent with the
+                    services and objectives of arXiv as stated in arXiv&rsquo;s policies.</li>
+                <li>I agree that this license includes without limitation the right for arXiv to reproduce (e.g.,
+                    upload, backup, archive, preserve, and allow online access), distribute (e.g., allow access to
+                    arXiv users), make available, and prepare versions of the Work in analog, digital, or other formats
+                    existing now or in the future as arXiv may deem appropriate, and permits arXiv to make
+                    non-commercial use of the Work as input in machine learning or generative artificial intelligence
+                    systems (or other similar systems that may exist in the future) created for or operated by arXiv
+                    (or on arXiv&rsquo;s behalf through its subcontractor) to enhance, improve, or expand any means of
+                    user access to the arXiv repository.</li>
+                <li>I agree that the rights and licenses granted may be assigned, transferred, or otherwise conveyed to
+                    another organization that is assuming (taking over) any arXiv responsibilities.</li>
+            </ul>
+
+            <p>This grant of license will be referred to here for all purposes as &ldquo;arXiv.org perpetual
+                non-exclusive license.&rdquo;</p>
+
+            <h4>Waiver of Rights and Indemnification</h4>
+
+            <p>I waive the following claims on behalf of myself and all other authors of the Work, with me agreeing on
+                my co-author(s)&rsquo; behalf:</p>
+
+            <ul>
+                <li>Any claims against arXiv, or any officer, director, employee, or agent, and their successors,
+                    assignees, or heirs thereof (hereinafter &ldquo;the indemnified parties&rdquo;), based upon the use
+                    of the Work by arXiv consistent with the arXiv.org perpetual non-exclusive license.</li>
+                <li>Any claims against the indemnified parties based upon actions taken by any such party with respect
+                    to the Work, including without limitation decisions to include the Work in, or exclude the Work
+                    from, the repository; editorial decisions or changes affecting the Work, including the
+                    identification of myself and contributing co-author(s) and our affiliations or titles; the
+                    classification or characterization of the Work; the content of any metadata; the availability or
+                    lack of availability of the Work to researchers or other users of arXiv, including any decision to
+                    include the Work initially or remove or disable access.</li>
+                <li>Any rights related to the integrity of the Work under moral rights principles.</li>
+                <li>Any claims against the indemnified parties based upon any technical failures that result in a loss
+                    of content or inadvertent disclosure of information provided in connection with the Work.</li>
+                <li>I will indemnify, defend, and hold harmless the indemnified parties from any loss, damage, or claim
+                    arising out of or related to: (a) any breach of any representations or warranties herein; (b) any
+                    failure by myself or my co-author(s) to perform any of our obligations herein; and (c) any use of
+                    the Work as anticipated in the arXiv.org perpetual non-exclusive license and terms of this
+                    Agreement.</li>
+            </ul>
+
+            <h4>Management of Copyright</h4>
+
+            <p>I understand that the grant to arXiv is a non-exclusive license and is not a grant of exclusive rights
+                or a transfer of copyright.</p>
+
+            <ul>
+                <li>I understand that I may enter into publication agreements or other arrangements regarding the Work
+                    as long as such agreements or other arrangements do not prohibit or impair the arXiv.org perpetual
+                    non-exclusive license or conflict with arXiv&rsquo;s ability to exercise the rights and licenses
+                    granted under this Agreement.</li>
+                <li>arXiv has no obligation to protect or enforce any copyright in the Work, and arXiv has no
+                    obligation to respond to any permission requests or other inquiries regarding the copyright in or
+                    other uses of the Work.</li>
+            </ul>
+
+            <p>I understand that, as part of the submission process, I can elect to apply an additional irrevocable
+                license, including a Creative Commons (CC) license, to allow for wider sharing and reuse of the Work,
+                only if I own or control copyright in the Work. I understand that different versions of the Work can
+                have different licenses. Before making any selection, I will review the Creative Commons licenses
+                explained here: <a href="https://creativecommons.org/licenses/" target="_blank"
+                rel="noopener">https://creativecommons.org/licenses/</a>.</p>
+
+            <p>If I wish to use a license that is not provided on the license selection screen, I will indicate the
+                desired license in a prominent location in the Work.</p>
+
+            <p>I understand that I should not submit a Work to arXiv if I may later wish to publish the Work in a
+                journal or other outlet that prohibits prior distribution on an e-print server. I understand that under
+                no circumstances will arXiv remove a Work from arXiv in order to comply with such a journal policy, and
+                the irrevocability of the arXiv.org perpetual non-exclusive license.</p>
+
+            <h4>Metadata license</h4>
+
+            <p>To the extent that I or arXiv has a copyright interest in metadata accompanying the submission, a
+                Creative Commons CC0 1.0 Universal Public Domain Dedication will apply. Metadata includes title, author,
+                abstract, and other information describing the Work.</p>
+
+            <h4>General Provisions</h4>
+
+            <p>This Agreement will be governed by and construed in accordance with the substantive and procedural laws
+                of the State of New York and the applicable federal law of the United States without reference to any
+                conflicts of laws principles.</p>
+
+            <ul>
+                <li>By making this submission, I agree that any action, suit, arbitration, or other proceeding arising
+                    out of or related to this Agreement must be commenced in the state or federal courts in New York
+                    County, New York.</li>
+                <li>I, for myself and on behalf of any and all authors, hereby consent to the personal jurisdiction of
+                    such courts.</li>
+            </ul>
         </div>
     </div>
 

--- a/submit_ce/ui/tests/integration/test_integration.py
+++ b/submit_ce/ui/tests/integration/test_integration.py
@@ -101,7 +101,7 @@ class TestSubmissionIntegration(unittest.TestCase):
         self.assertIn('policy', self.next_page, "URL should be to policy")
         res = self.client.get(self.next_page)
         self.assertEqual(res.status_code, 200)
-        self.assertIn('Read and accept the Submission Agreement before proceeding', res.text)
+        self.assertIn('Scroll to read and accept the arXiv Submission Agreement before proceeding', res.text)
         res = self.client.post(self.next_page,
                             data={'policy': 'y',
                                   'action': 'next',


### PR DESCRIPTION
This tiny PR installs the final submission agreement content.

<img width="1045" height="1012" alt="UpdatedSubmissionAgreement-Screenshot 2026-07-27 at 12 13 15 PM" src="https://github.com/user-attachments/assets/4808e46c-6322-4afc-9cde-a74470dff5c3" />

I have included a PDF preview of the submission agreement. 

[SUBMISSION-123_agreement_preview.pdf](https://github.com/user-attachments/files/30424592/SUBMISSION-123_agreement_preview.pdf)
