### PR TITLE
SUBMISSION-209: guard selected top-level TeX file(s) from deletion

### DIFF
--- a/submit_ce/domain/event/process.py
+++ b/submit_ce/domain/event/process.py
@@ -471,6 +471,23 @@ class PreflightStatus(Event):
         return submission
 
 
+def _protected_top_level_sources(decisions: dict) -> set[str]:
+    """Filenames that must never be deleted: user-selected top-level TeX files.
+
+    A source is treated as top-level when its ``usage`` is ``'toplevel'`` or is
+    unset -- the Review Files form lists only top-level sources and does not
+    always set an explicit usage. Handles one or more selected top-level files
+    (SUBMISSION-209).
+    """
+    sources = (decisions or {}).get('sources') or []
+    protected: set[str] = set()
+    for src in sources:
+        filename = src.get('filename')
+        if filename and src.get('usage', 'toplevel') in (None, 'toplevel'):
+            protected.add(filename)
+    return protected
+
+
 class SetDecisions(EventWithSideEffect):
     """Sets the decisions for the submission."""
 
@@ -508,7 +525,17 @@ class SetDecisions(EventWithSideEffect):
         # Delete files and only delete preflight and user_decisions if at least one file is deleted
         file_store.delete_preflight(submission.submission_id)
         file_store.store_user_decisions(submission.submission_id, self.decisions)
+        # Authoritative guard (SUBMISSION-209): never delete a file the user has
+        # selected as a top-level TeX file -- that's what we're about to compile.
+        # Runs under the submission row lock taken by save(), so it can't race a
+        # concurrent decisions change.
+        protected = _protected_top_level_sources(self.decisions)
         for path in self.files_to_delete:
+            if path in protected:
+                logger.warning(
+                    "Refusing to delete selected top-level file %s for "
+                    "submission %s", path, submission.submission_id)
+                continue
             file = file_store.delete_source_file(submission.submission_id, path)
             if file:
                 self.bytes_removed += file.bytes

--- a/submit_ce/domain/event/tests/test_set_decisions_guard.py
+++ b/submit_ce/domain/event/tests/test_set_decisions_guard.py
@@ -1,0 +1,117 @@
+"""Tests for the ``SetDecisions`` delete guard. [SUBMISSION-209]
+
+The guard: ``SetDecisions.execute`` must never delete a file listed as a
+top-level source in ``decisions`` -- that's the file(s) we're about to
+compile -- even if it appears in ``files_to_delete``. This is the
+authoritative check; it runs under the submission row lock taken by
+``save()``. Exercised directly with a hand-rolled fake store, matching the
+style of ``test_store_zzrm.py``.
+"""
+
+from datetime import datetime
+
+from pytz import UTC
+
+from submit_ce.domain import submission as submod, agent
+from submit_ce.domain.event.process import (
+    SetDecisions,
+    _protected_top_level_sources,
+)
+
+
+class _FakeFile:
+    def __init__(self, nbytes):
+        self.bytes = nbytes
+
+
+class _FakeStore:
+    def __init__(self):
+        self.deleted = []
+        self.user_decisions = None
+        self.preflight_deleted = False
+
+    def delete_preflight(self, sid):
+        self.preflight_deleted = True
+
+    def store_user_decisions(self, sid, decisions):
+        self.user_decisions = decisions
+
+    def delete_source_file(self, sid, path):
+        self.deleted.append(path)
+        return _FakeFile(10)
+
+
+class _FakeApi:
+    def __init__(self):
+        self._store = _FakeStore()
+
+    def get_file_store(self):
+        return self._store
+
+
+def _user(uid="u1"):
+    return agent.PublicUser(name="Test User", user_id=uid,
+                            email=f"{uid}@example.org", endorsements=[])
+
+
+def _submission(sid="1234567"):
+    u = _user()
+    s = submod.Submission(creator=u, owner=u, created=datetime.now(UTC))
+    s.submission_id = sid
+    return s
+
+
+def test_execute_skips_selected_top_level_file():
+    """A top-level source is never deleted; siblings still are."""
+    s = _submission()
+    api = _FakeApi()
+    e = SetDecisions(
+        creator=s.creator,
+        decisions={'sources': [{'filename': 'main.tex', 'usage': 'toplevel'}]},
+        files_to_delete=['main.tex', 'junk.tex'],
+    )
+    e.execute(api, s)
+    assert 'main.tex' not in api._store.deleted
+    assert api._store.deleted == ['junk.tex']
+
+
+def test_execute_protects_source_without_explicit_usage():
+    """The Review Files form lists sources without a usage; treat as toplevel."""
+    s = _submission()
+    api = _FakeApi()
+    e = SetDecisions(
+        creator=s.creator,
+        decisions={'sources': [{'filename': 'main.tex'}]},
+        files_to_delete=['main.tex'],
+    )
+    e.execute(api, s)
+    assert api._store.deleted == []
+    assert e.bytes_removed == 0
+
+
+def test_execute_deletes_non_toplevel_and_counts_bytes():
+    """Non-top-level files are deleted and their bytes counted."""
+    s = _submission()
+    api = _FakeApi()
+    e = SetDecisions(
+        creator=s.creator,
+        decisions={'sources': [{'filename': 'main.tex'}]},
+        files_to_delete=['fig.png', 'old.bbl'],
+    )
+    e.execute(api, s)
+    assert api._store.deleted == ['fig.png', 'old.bbl']
+    assert e.bytes_removed == 20
+
+
+def test_protected_top_level_sources_helper():
+    """toplevel + usage-less sources are protected; include/ignore are not."""
+    decisions = {'sources': [
+        {'filename': 'a.tex', 'usage': 'toplevel'},
+        {'filename': 'b.tex'},                       # no usage -> protected
+        {'filename': 'c.sty', 'usage': 'include'},   # not protected
+        {'filename': 'd.bib', 'usage': 'ignore'},    # not protected
+        {'usage': 'toplevel'},                       # no filename -> ignored
+    ]}
+    assert _protected_top_level_sources(decisions) == {'a.tex', 'b.tex'}
+    assert _protected_top_level_sources({}) == set()
+    assert _protected_top_level_sources({'sources': []}) == set()

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -154,6 +154,7 @@ def review_files(method: str, params: MultiDict, session: Session,
         'form': form,
         'preflight_files': {},
         'file_notes': {},
+        'selected_top_level_files': [],
     }
 
     if not workspace:
@@ -187,6 +188,7 @@ def review_files(method: str, params: MultiDict, session: Session,
 
         rdata['file_notes'] = dm.get_files_from_preflight(preflight_data)
         _populate_form(form, preflight_data, user_decisions_data)
+        rdata['selected_top_level_files'] = [f for f in [form.source_file.data] if f]
         rdata['immediate_notifications'] = _get_notifications(submission_id, preflight_data)
 
         return stay_on_this_stage((rdata, status.OK, {}))
@@ -244,9 +246,40 @@ def _get_user_decisions_data(submission_id: str) -> Optional[dict]:
         return None
     return json.loads(blob.download_as_text())
 
+def _selected_top_level_files(params: MultiDict) -> list[str]:
+    """Return the top-level TeX file(s) the user has selected, in order.
+
+    Supports the current single ``source_file`` field and a future multi-select
+    (``top_level_tex_files[]``), so the delete guard already handles one or more
+    selected top-level files (SUBMISSION-209 / C2).
+    """
+    values = list(params.getlist('source_file')) + \
+        list(params.getlist('top_level_tex_files[]'))
+    seen: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.append(value)
+    return seen
+
+
 def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspace, submitter, client) -> bool:
     existing_paths = {f.path for f in workspace.files}
     files_to_delete = [p for p in params.getlist('selected_files') if p in existing_paths]
+
+    # Never delete a file the user has selected as a top-level TeX file -- that's
+    # what we're about to compile (SUBMISSION-209). The template disables these
+    # checkboxes, but a crafted or stale POST can still carry them, so we filter
+    # here and warn the user. The authoritative guard is in SetDecisions.execute,
+    # which runs under the submission row lock.
+    selected_top_levels = _selected_top_level_files(params)
+    protected = [p for p in files_to_delete if p in selected_top_levels]
+    if protected:
+        files_to_delete = [p for p in files_to_delete if p not in selected_top_levels]
+        alerts.flash_warning(
+            "We kept your selected top-level TeX file(s) and did not delete "
+            f"them: {', '.join(protected)}. To delete one, first remove it from "
+            "the Top-Level TeX selection.",
+            title="Top-level file not deleted")
 
     # If the POST carries none of the review-form fields, the user clicked
     # "next" without changing anything; don't invalidate preflight.

--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -309,6 +309,64 @@ def test_update_preflight_invalid_event_returns_false(
     mock_save.assert_called_once()
 
 
+def test_selected_top_level_files_dedupes_and_orders():
+    """_selected_top_level_files reads source_file + top_level_tex_files[],
+    de-duped and order-preserving (SUBMISSION-209)."""
+    params = MultiDict([
+        ('source_file', 'a.tex'),
+        ('top_level_tex_files[]', 'b.tex'),
+        ('top_level_tex_files[]', 'a.tex'),
+        ('top_level_tex_files[]', ''),
+    ])
+    assert review._selected_top_level_files(params) == ['a.tex', 'b.tex']
+
+
+def test_update_preflight_protects_selected_top_level_file(
+        app, authorized_user, mocker):
+    """A file that is the selected top-level TeX file is filtered out of the
+    deletion set and the user is warned; other deletions proceed (SUBMISSION-209)."""
+    mocker.patch.object(review, '_get_user_decisions_data', return_value=None)
+    mock_flash = mocker.patch.object(review.alerts, 'flash_warning')
+    with app.app_context():
+        mock_save = mocker.patch.object(app.api, 'save')
+        params = MultiDict([
+            ('source_file', 'main.tex'),
+            ('compiler', 'pdflatex'),
+            ('compiler_version', '2025'),
+            ('selected_files', 'main.tex'),
+            ('selected_files', 'junk.tex'),
+        ])
+        result = review._update_preflight(
+            params, 'sub1', _make_workspace('main.tex', 'junk.tex'),
+            authorized_user, None,
+        )
+    assert result is True
+    mock_flash.assert_called_once()
+    cmd = mock_save.call_args[0][0]
+    assert 'main.tex' not in cmd.files_to_delete
+    assert cmd.files_to_delete == ['junk.tex']
+
+
+def test_update_preflight_no_warning_when_top_level_not_marked(
+        app, authorized_user, mocker):
+    """When the selected top-level isn't marked for deletion, no warning fires."""
+    mocker.patch.object(review, '_get_user_decisions_data', return_value=None)
+    mock_flash = mocker.patch.object(review.alerts, 'flash_warning')
+    with app.app_context():
+        mocker.patch.object(app.api, 'save')
+        params = MultiDict([
+            ('source_file', 'main.tex'),
+            ('compiler', 'pdflatex'),
+            ('compiler_version', '2025'),
+            ('selected_files', 'junk.tex'),
+        ])
+        review._update_preflight(
+            params, 'sub1', _make_workspace('main.tex', 'junk.tex'),
+            authorized_user, None,
+        )
+    mock_flash.assert_not_called()
+
+
 def test_populate_form_choices_come_from_enums_and_preflight(app):
     """compiler/compiler_version choices come from Compilation enums;
     source_file choices come from preflight tex_files."""

--- a/submit_ce/ui/static/js/review_top_level_guard.js
+++ b/submit_ce/ui/static/js/review_top_level_guard.js
@@ -1,0 +1,65 @@
+// review_top_level_guard.js  (SUBMISSION-209)
+//
+// Progressive enhancement for the Review Files page. Keeps each file's Delete
+// checkbox in sync with the currently-selected top-level TeX file(s) *without*
+// a server round-trip: a selected top-level file is what we are about to
+// compile, so it must not be deletable, and a file that is no longer a
+// top-level should become deletable again.
+//
+// This only mirrors, in the browser, a rule the server already enforces
+// authoritatively (SetDecisions refuses to delete a selected top-level file).
+// With JavaScript off, the page still behaves correctly -- the checkbox states
+// simply update on the next server render instead of live.
+//
+// Written to handle one OR MORE top-level selects, so it is ready for the
+// multiple-top-level UI (C2).
+(function () {
+  "use strict";
+
+  function topLevelSelects() {
+    return document.querySelectorAll(
+      'select[name="source_file"], select[name="top_level_tex_files[]"]'
+    );
+  }
+
+  function selectedTopLevelFiles() {
+    var files = [];
+    topLevelSelects().forEach(function (sel) {
+      if (sel.value && files.indexOf(sel.value) === -1) {
+        files.push(sel.value);
+      }
+    });
+    return files;
+  }
+
+  function deleteCheckboxes() {
+    return document.querySelectorAll('input[name="selected_files"]');
+  }
+
+  // Recompute every delete checkbox from the current top-level selection.
+  function syncGuards() {
+    var selected = selectedTopLevelFiles();
+    deleteCheckboxes().forEach(function (cb) {
+      // Never touch permanently-locked rows (e.g. 00README.json).
+      if (cb.dataset.lock === "permanent") {
+        return;
+      }
+      if (selected.indexOf(cb.value) !== -1) {
+        // A selected top-level file: uncheck and lock against deletion.
+        cb.checked = false;
+        cb.disabled = true;
+      } else {
+        // No longer a top-level file: allow deletion again.
+        cb.disabled = false;
+      }
+    });
+  }
+
+  window.addEventListener("DOMContentLoaded", function () {
+    topLevelSelects().forEach(function (sel) {
+      sel.addEventListener("change", syncGuards);
+    });
+    // Re-assert on load so the client state matches the current selection.
+    syncGuards();
+  });
+})();

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -3,23 +3,30 @@
 {% block addl_head %}
 {{super()}}
  <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
+ <script src="{{ url_for('static', filename='js/review_top_level_guard.js') }}" defer></script>
 {% endblock addl_head %}
 
 {# Renders one row of the Review Files table for a preflight-detected file,
    or recurses into a subdirectory listing. The third argument
-   ``top_level_filename`` is the currently-selected top-level TeX file
-   (form.source_file.data) so we can render "Used: top-level file" for it.
-   00README.json gets a dedicated label and a disabled delete checkbox --
-   it's a build-directives file, not a candidate for deletion. #}
-{% macro display_preflight_tree(key, item, top_level_filename) %}
+   ``top_level_filenames`` is the list of currently-selected top-level TeX
+   files (one or more) so we can render "Used: top-level file" for each and
+   disable its delete checkbox -- a selected top-level file is what we're about
+   to compile and must not be deletable here (SUBMISSION-209).
+   00README.json likewise gets a dedicated label and a disabled delete
+   checkbox -- it's a build-directives file, not a candidate for deletion. #}
+{% macro display_preflight_tree(key, item, top_level_filenames) %}
   {% if 'filename' in item %}
   <tr>
     <td class="has-text-centered">
       <input type="hidden" name="all_files" value="{{ item.filename }}">
       {% if item.filename == '00README.json' %}
         <input type="checkbox" name="selected_files" value="{{ item.filename }}"
-               disabled
+               disabled data-lock="permanent"
                title="00README.json contains build directives and cannot be deleted from this step">
+      {% elif item.filename in top_level_filenames %}
+        <input type="checkbox" name="selected_files" value="{{ item.filename }}"
+               disabled
+               title="This is a selected top-level TeX file and cannot be deleted here. Remove it from the Top-Level TeX selection first.">
       {% else %}
         <input type="checkbox" name="selected_files" value="{{ item.filename }}">
       {% endif %}
@@ -28,7 +35,7 @@
     <td>
       {% if item.filename == '00README.json' %}
         Build directives file
-      {% elif item.filename == top_level_filename %}
+      {% elif item.filename in top_level_filenames %}
         Used: top-level file
       {% else %}
         {% if item.used_by %}Used by: {{ item.used_by | join(', ') }}<br>{% endif %}
@@ -40,7 +47,7 @@
   {% else %}
   <tr><td colspan="3"><em>{{ key }}/</em></td></tr>
   {% for k, subitem in item.items() %}
-    {{ display_preflight_tree(k, subitem, top_level_filename) }}
+    {{ display_preflight_tree(k, subitem, top_level_filenames) }}
   {% endfor %}
   {% endif %}
 {% endmacro %}
@@ -201,7 +208,7 @@
       </thead>
       <tbody>
         {% for k, item in (file_notes | group_preflight_files).items() %}
-          {{ display_preflight_tree(k, item, form.source_file.data) }}
+          {{ display_preflight_tree(k, item, selected_top_level_files) }}
         {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
Prevent deleting a file the user has selected as a top-level TeX file on the Review Files step (one or more selected files). A small piece of Javascript is added to updated to UI checkboxes upon a top-level file change. This avoids calling preflight on every change action. If Javascript is to be avoided, we can perform server side calls or revisit this decision in the future.

- SetDecisions.execute skips deleting any top-level source, authoritative and under the submission row lock; add _protected_top_level_sources helper.
- review._update_preflight filters selected top-levels out of the delete set and flashes a warning; add _selected_top_level_files (reads source_file and future top_level_tex_files[]).
- review_files.html disables the delete checkbox for selected top-level file(s); macro now takes a list of selected top-levels.
- Add review_top_level_guard.js: progressive-enhancement that syncs the Delete checkboxes with the current selection without a server round-trip.
- Tests: test_set_decisions_guard.py + new _update_preflight cases in test_review.py.