### PR TITLE
SUBMISSION-210: Surface preflight issues on the Review Files page

### DIFF
--- a/submit_ce/ui/controllers/new/preflight_issues.py
+++ b/submit_ce/ui/controllers/new/preflight_issues.py
@@ -1,0 +1,143 @@
+"""Extract preflight issues from a preflight payload for the Review Files page.
+
+[SUBMISSION-210] Consumes the presentation table in ``preflight_issue_table`` to
+turn a preflight response into two things for the Review Files template:
+
+* **page-level notifications** grouped by reason code, shaped for the existing
+  ``immediate_notifications`` loop; and
+* **per-file issue badges** for the "Auto-detected Notes" column.
+
+The severity/message table itself lives in ``preflight_issue_table`` (reviewed
+separately under SUBMISSION-211); this module is only the extraction logic.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from submit_ce.ui.controllers.new.preflight_issue_table import (
+    DEFAULT_DIRECTIVE,
+    PREFLIGHT_ISSUE_DIRECTIVES,
+    SEVERITY_RANK,
+    SILENT,
+    directive_for,
+)
+
+# Backwards-compatible aliases for existing references within this module.
+_directive = directive_for
+_SEVERITY_RANK = SEVERITY_RANK
+
+# Codes whose named file is a *referenced / missing* file rather than the file
+# that carries the issue. For these, the name (issue.filename or issue.info)
+# identifies a file that is NOT in the source, so it must NOT be attributed to
+# the carrying file (that file exists) and gets no per-row badge -- it is only
+# named in the banner. Producer: file_not_found is raised on the referencing
+# node with the missing name in `info` (preflight/__init__.py:1307) or in
+# `filename` for the bib variant (:1589).
+_REFERENCED_FILE_CODES = {"file_not_found"}
+
+
+def _humanize(key: str) -> str:
+    return key.replace("_", " ")
+
+
+def _directive(key: str) -> Dict[str, Any]:
+    return PREFLIGHT_ISSUE_DIRECTIVES.get(key, DEFAULT_DIRECTIVE)
+
+
+def _iter_issues(preflight_data: dict):
+    """Yield ``(key, info, filename, container)`` for every issue in the payload.
+
+    Issues live at two levels in a ``PreflightResponse``:
+    ``detected_toplevel_files[].issues`` (document-level) and
+    ``tex_files[].issues`` (per source file). ``filename`` is the issue's own
+    filename (often unset); ``container`` is the ``tex_file`` that carries it
+    (``None`` for document-level issues). Keeping them distinct matters for
+    referenced-file codes (see ``_REFERENCED_FILE_CODES``).
+    """
+    for tlf in preflight_data.get("detected_toplevel_files") or []:
+        for issue in tlf.get("issues") or []:
+            yield issue.get("key"), issue.get("info"), issue.get("filename"), None
+    for tex_file in preflight_data.get("tex_files") or []:
+        container = tex_file.get("filename")
+        for issue in tex_file.get("issues") or []:
+            yield (issue.get("key"), issue.get("info"),
+                   issue.get("filename"), container)
+
+
+def _derived_issues(preflight_data: dict):
+    """Issues we synthesize because the producer no longer emits them.
+
+    Currently just ``hyperref_not_found``: any detected top-level file whose
+    ``hyperref_found`` is explicitly ``False``.
+    """
+    toplevels = preflight_data.get("detected_toplevel_files") or []
+    if any(tlf.get("hyperref_found") is False for tlf in toplevels):
+        yield "hyperref_not_found", None, None, None
+
+
+def build_issue_context(
+    preflight_data: Optional[dict],
+) -> Tuple[List[Dict[str, Any]], Dict[str, List[Dict[str, str]]]]:
+    """Return ``(notifications, file_issues)`` for the Review Files template.
+
+    ``notifications`` -- one dict per reason-code group, ordered danger-first:
+    ``{title, severity, body, url?, link_text?}`` for the existing
+    ``immediate_notifications`` loop.
+
+    ``file_issues`` -- ``{filename: [{severity, label}, ...]}`` for per-row
+    badges in the Notes column.
+
+    Silent codes are skipped entirely (banners and badges), matching 1.5.
+    """
+    notifications: List[Dict[str, Any]] = []
+    file_issues: Dict[str, List[Dict[str, str]]] = {}
+    if not preflight_data:
+        return notifications, file_issues
+
+    groups: Dict[str, Dict[str, Any]] = {}
+    all_issues = list(_iter_issues(preflight_data)) + \
+        list(_derived_issues(preflight_data))
+    for key, info, filename, container in all_issues:
+        if not key:
+            continue
+        severity = _directive(key).get("severity", "warning")
+        if severity == SILENT:
+            continue
+        group = groups.setdefault(
+            key, {"count": 0, "files": [], "severity": severity})
+        group["count"] += 1
+
+        if key in _REFERENCED_FILE_CODES:
+            # The named file is a *missing* file (not the carrier); list it in
+            # the banner but never badge -- it has no row, and the carrier is
+            # fine.
+            subject = filename or info
+            badge_target = None
+        else:
+            # The issue is about the carrying file (or its own filename).
+            subject = filename or container
+            badge_target = subject
+
+        if subject and subject not in group["files"]:
+            group["files"].append(subject)
+        if badge_target:
+            file_issues.setdefault(badge_target, []).append(
+                {"severity": severity, "label": _humanize(key)})
+
+    for key in sorted(groups,
+                      key=lambda k: (_SEVERITY_RANK.get(groups[k]["severity"], 9), k)):
+        group = groups[key]
+        directive = _directive(key)
+        message = directive.get("message") or f"{_humanize(key)} ({{n}} issue(s))"
+        notification: Dict[str, Any] = {
+            "title": message.replace("{n}", str(group["count"])),
+            "severity": group["severity"],
+            "body": ("Affected file(s): " + ", ".join(group["files"]))
+                    if group["files"] else "",
+        }
+        if directive.get("url"):
+            notification["url"] = directive["url"]
+            notification["link_text"] = directive.get("link_text", "Learn more")
+        notifications.append(notification)
+
+    return notifications, file_issues

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -30,7 +30,7 @@ from wtforms.validators import DataRequired
 from submit_ce.domain.uploads import Workspace, SourceFormat
 from submit_ce.domain.exceptions import InvalidEvent, SaveError
 from submit_ce.ui.controllers.util import validate_command
-from submit_ce.ui.controllers.new.preflight_issues import build_issue_context
+from submit_ce.ui.preflight.issues import build_issue_context
 from submit_ce.ui.routes.flow_control import (
     stay_on_this_stage, ready_for_next, return_to_parent_stage,
     return_to_previous_stage, advance_to_current,

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -30,6 +30,7 @@ from wtforms.validators import DataRequired
 from submit_ce.domain.uploads import Workspace, SourceFormat
 from submit_ce.domain.exceptions import InvalidEvent, SaveError
 from submit_ce.ui.controllers.util import validate_command
+from submit_ce.ui.controllers.new.preflight_issues import build_issue_context
 from submit_ce.ui.routes.flow_control import (
     stay_on_this_stage, ready_for_next, return_to_parent_stage,
     return_to_previous_stage, advance_to_current,
@@ -155,6 +156,7 @@ def review_files(method: str, params: MultiDict, session: Session,
         'preflight_files': {},
         'file_notes': {},
         'selected_top_level_files': [],
+        'file_issues': {},
     }
 
     if not workspace:
@@ -189,7 +191,13 @@ def review_files(method: str, params: MultiDict, session: Session,
         rdata['file_notes'] = dm.get_files_from_preflight(preflight_data)
         _populate_form(form, preflight_data, user_decisions_data)
         rdata['selected_top_level_files'] = [f for f in [form.source_file.data] if f]
-        rdata['immediate_notifications'] = _get_notifications(submission_id, preflight_data)
+        # Surface preflight issues (SUBMISSION-210): reason-code-grouped banners
+        # + per-file badges, extracted server-side. Issue banners lead; the
+        # backend-status cards follow.
+        issue_notifications, file_issues = build_issue_context(preflight_data)
+        rdata['file_issues'] = file_issues
+        rdata['immediate_notifications'] = (
+            issue_notifications + _get_notifications(submission_id, preflight_data))
 
         return stay_on_this_stage((rdata, status.OK, {}))
 

--- a/submit_ce/ui/controllers/new/tests/test_preflight_issues.py
+++ b/submit_ce/ui/controllers/new/tests/test_preflight_issues.py
@@ -1,0 +1,133 @@
+"""Tests for :mod:`submit_ce.ui.controllers.new.preflight_issues`. [SUBMISSION-210]"""
+
+import pytest
+
+from submit_ce.ui.controllers.new.preflight_issues import (
+    PREFLIGHT_ISSUE_DIRECTIVES,
+    build_issue_context,
+)
+
+
+def test_directives_cover_every_producer_issue_type():
+    """Every IssueType the preflight producer can emit has a directive, so new
+    producer codes can't silently fall through to the default unnoticed."""
+    from tex2pdf_tools.preflight.models import IssueType
+    missing = [it.value for it in IssueType
+               if it.value not in PREFLIGHT_ISSUE_DIRECTIVES]
+    assert missing == [], f"IssueType codes without a directive: {missing}"
+
+
+def test_empty_and_none_preflight_yield_nothing():
+    assert build_issue_context(None) == ([], {})
+    assert build_issue_context({}) == ([], {})
+
+
+def test_file_not_found_names_missing_files_not_the_carrier():
+    """file_not_found is raised on the *referencing* file with the missing name
+    in `info` (producer __init__.py:1307) or in `filename` for the bib variant
+    (:1589). The banner must name the MISSING files, never badge the existing
+    carrier as if it were missing (regression: an existing top-level file was
+    labelled 'file not found')."""
+    preflight = {
+        'tex_files': [
+            {'filename': 'main.tex',
+             'issues': [
+                 {'key': 'file_not_found', 'info': 'a.sty'},           # :1307
+                 {'key': 'file_not_found', 'info': 'bib file missing',
+                  'filename': 'refs.bib'},                              # :1589
+             ]},
+        ],
+    }
+    notifications, file_issues = build_issue_context(preflight)
+
+    assert len(notifications) == 1
+    note = notifications[0]
+    assert note['severity'] == 'warning'
+    assert '2 file(s) missing' in note['title']            # {n} substituted
+    # Banner names the missing files, not the carrier.
+    assert 'a.sty' in note['body'] and 'refs.bib' in note['body']
+    assert 'main.tex' not in note['body']
+    # No per-file badge: the missing files have no row, the carrier is fine.
+    assert file_issues == {}
+
+
+def test_per_file_badge_attaches_to_the_real_file():
+    """For non-referenced codes, the badge attaches to the issue's own file."""
+    preflight = {
+        'detected_toplevel_files': [
+            {'filename': 'main.tex',
+             'issues': [{'key': 'oversized_image', 'info': 'x',
+                         'filename': 'big.png'}]},
+        ],
+    }
+    _, file_issues = build_issue_context(preflight)
+    assert file_issues['big.png'][0] == {'severity': 'warning',
+                                        'label': 'oversized image'}
+
+
+def test_silent_codes_are_skipped_everywhere():
+    preflight = {
+        'tex_files': [
+            {'filename': 'main.tex',
+             'issues': [{'key': 'issue_in_subfile', 'info': '1',
+                         'filename': 'sub.tex'}]},
+        ],
+    }
+    notifications, file_issues = build_issue_context(preflight)
+    assert notifications == []
+    assert file_issues == {}
+
+
+def test_hyperref_not_found_is_derived_from_boolean():
+    """hyperref_not_found is no longer an emitted issue; it's derived from
+    ToplevelFile.hyperref_found == False."""
+    preflight = {
+        'detected_toplevel_files': [
+            {'filename': 'main.tex', 'hyperref_found': False, 'issues': []},
+        ],
+    }
+    notifications, _ = build_issue_context(preflight)
+    titles = [n['title'] for n in notifications]
+    assert any('hyperref' in t for t in titles)
+    assert notifications[0]['severity'] == 'info'
+
+
+def test_unsupported_compiler_carries_learn_more_link():
+    preflight = {
+        'detected_toplevel_files': [
+            {'filename': 'main.tex',
+             'issues': [{'key': 'unsupported_compiler_type', 'info': 'x'}]},
+        ],
+    }
+    notifications, _ = build_issue_context(preflight)
+    note = notifications[0]
+    assert note['severity'] == 'danger'
+    assert note['url'].startswith('https://')
+    assert note['link_text']
+
+
+def test_notifications_ordered_danger_first():
+    preflight = {
+        'detected_toplevel_files': [
+            {'filename': 'main.tex',
+             'issues': [{'key': 'oversized_image', 'info': 'x', 'filename': 'f.png'},
+                        {'key': 'bbl_bib_file_missing', 'info': 'y'}]},
+        ],
+    }
+    notifications, _ = build_issue_context(preflight)
+    severities = [n['severity'] for n in notifications]
+    assert severities == ['danger', 'warning']
+
+
+def test_tex_file_issue_without_filename_uses_container():
+    """A per-file issue with no explicit filename is attributed to the tex file
+    that carries it."""
+    preflight = {
+        'tex_files': [
+            {'filename': 'main.tex',
+             'issues': [{'key': 'conflicting_file_type', 'info': 'z'}]},
+        ],
+    }
+    _, file_issues = build_issue_context(preflight)
+    assert 'main.tex' in file_issues
+    assert file_issues['main.tex'][0]['severity'] == 'danger'

--- a/submit_ce/ui/preflight/issues.py
+++ b/submit_ce/ui/preflight/issues.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from submit_ce.ui.controllers.new.preflight_issue_table import (
+from submit_ce.ui.preflight.issue_table import (
     DEFAULT_DIRECTIVE,
     PREFLIGHT_ISSUE_DIRECTIVES,
     SEVERITY_RANK,

--- a/submit_ce/ui/preflight/tests/test_issues.py
+++ b/submit_ce/ui/preflight/tests/test_issues.py
@@ -1,8 +1,8 @@
-"""Tests for :mod:`submit_ce.ui.controllers.new.preflight_issues`. [SUBMISSION-210]"""
+"""Tests for :mod:`submit_ce.ui.preflight.issues`. [SUBMISSION-210]"""
 
 import pytest
 
-from submit_ce.ui.controllers.new.preflight_issues import (
+from submit_ce.ui.preflight.issues import (
     PREFLIGHT_ISSUE_DIRECTIVES,
     build_issue_context,
 )

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -12,9 +12,10 @@
    files (one or more) so we can render "Used: top-level file" for each and
    disable its delete checkbox -- a selected top-level file is what we're about
    to compile and must not be deletable here (SUBMISSION-209).
+   ``file_issues`` maps filename -> per-file preflight issue badges (SUBMISSION-210).
    00README.json likewise gets a dedicated label and a disabled delete
    checkbox -- it's a build-directives file, not a candidate for deletion. #}
-{% macro display_preflight_tree(key, item, top_level_filenames) %}
+{% macro display_preflight_tree(key, item, top_level_filenames, file_issues) %}
   {% if 'filename' in item %}
   <tr>
     <td class="has-text-centered">
@@ -33,6 +34,12 @@
     </td>
     <td>{{ item.filename }}</td>
     <td>
+      {# Preflight issue badges (SUBMISSION-210), severity-colored, before the
+         auto-detected usage note. #}
+      {% set file_issue_list = file_issues.get(item.filename) if file_issues else None %}
+      {% if file_issue_list %}
+        {% for issue in file_issue_list %}<span class="tag is-{{ issue.severity }}">{{ issue.label }}</span> {% endfor %}<br>
+      {% endif %}
       {% if item.filename == '00README.json' %}
         Build directives file
       {% elif item.filename in top_level_filenames %}
@@ -47,7 +54,7 @@
   {% else %}
   <tr><td colspan="3"><em>{{ key }}/</em></td></tr>
   {% for k, subitem in item.items() %}
-    {{ display_preflight_tree(k, subitem, top_level_filenames) }}
+    {{ display_preflight_tree(k, subitem, top_level_filenames, file_issues) }}
   {% endfor %}
   {% endif %}
 {% endmacro %}
@@ -112,9 +119,14 @@
   {% for notification in immediate_notifications %}
   <div class="notification is-{{ notification.severity }}" role="alert" aria-atomic="true">
     {% if notification.title %}<h2 class="is-size-5 is-marginless">{{ notification.title }}</h2>{% endif %}
+    {% if notification.body %}
     <p>
-      {{ notification.body}}
+      {{ notification.body }}
     </p>
+    {% endif %}
+    {% if notification.url %}
+    <p><a href="{{ notification.url }}">{{ notification.link_text }}</a></p>
+    {% endif %}
   </div>
   {% endfor %}
 {% endif %}
@@ -208,7 +220,7 @@
       </thead>
       <tbody>
         {% for k, item in (file_notes | group_preflight_files).items() %}
-          {{ display_preflight_tree(k, item, selected_top_level_files) }}
+          {{ display_preflight_tree(k, item, selected_top_level_files, file_issues) }}
         {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
Base: SUBMISSION-211-PreflightIssuesSeverityTable (stacked — this PR consumes the severity/message table from #211 and shouldn't merge before it).

**What this does**

Extracts preflight issues server-side and renders them on the Review Files page — no JavaScript. Turns a preflight response into:

Grouped banners, one per reason code, ordered danger → warning → info, shaped for the existing immediate_notifications loop. {n} in a message is replaced by the count for that code.
Per-file badges in the "Auto-detected Notes" column.

Severity and copy come entirely from the table in #211 (preflight_issue_table.py); this PR is just the extraction + rendering logic. hyperref_not_found is synthesized from the hyperref_found boolean, and silent codes (e.g. issue_in_subfile) are collected but never shown, matching 1.5.

**Files**

preflight_issues.py — extractor (build_issue_context, _iter_issues, _derived_issues); imports the table from #211.
review.py — wires build_issue_context into the Review Files GET path.
templates/submit/review_files.html — renders banners + badges.
tests/test_preflight_issues.py — extractor tests.

**Out of scope (follow-ups)**

Gating Continue on danger (C1.4) — not in this PR; the invariant is documented but not yet enforced here.
Issues that arrive via preflight status rather than issues[] (pdf_not_pdf, no-top-level) aren't surfaced yet — tracked separately.
The severity values themselves are still under review in #211.

**Testing**

Verified against a set of crafted submissions in testing/preflight_error_submissions/ (one per code, plus 19_multiple_issues which triggers a danger + several warnings + an info at once). Upload a single tarball to a fresh submission to see each case; 19_multiple_issues is the best for exercising banner grouping and ordering.

**Known limitations / related**

G31: the Review Files file list is enumerated from the preflight report, so files preflight doesn't enumerate (e.g. 00README.yaml, stray non-TeX files) don't appear as rows — captured as discovery ticket D1.
conflicting_output_type is defined in the table but currently never emitted by the producer (an overwrite bug in guess_compilation_parameters); kept for when that's fixed.
Discovery ticket D2 (severity by used/unused) is a related follow-up.

Here is a screenshot for a submission that contains multiple issues:

<img width="1307" height="1573" alt="ReiewFilesWithIssues-Screenshot 2026-07-30 at 3 20 04 PM" src="https://github.com/user-attachments/assets/9975551b-78d0-44d2-95cc-498925604660" />
