### PR TITLE
SUBMISSION-215: Skip preflight re-run on selection-only changes

### DIFF
--- a/submit_ce/domain/event/process.py
+++ b/submit_ce/domain/event/process.py
@@ -526,7 +526,7 @@ class SetDecisions(EventWithSideEffect):
         # them here; the controller regenerates them from the new decisions.
         file_store.delete_directives(submission.submission_id)
         # Preflight analyses the *file set*, not the selection. Only invalidate it
-        # when files are actually removed (G29 / SUBMISSION-215). A selection-only
+        # when files are actually removed (SUBMISSION-215). A selection-only
         # change (compiler / top-level) leaves the report valid, so the submitter is
         # not bounced back to Upload for a needless re-scan.
         if self.files_to_delete:

--- a/submit_ce/domain/event/process.py
+++ b/submit_ce/domain/event/process.py
@@ -521,10 +521,16 @@ class SetDecisions(EventWithSideEffect):
 
     def execute(self, api: SubmitApi, submission: Submission) -> None:
         file_store = api.get_file_store()
-        # TODO If something fails here, preflight/user_decisions are already changed/deleted.
-        # Delete files and only delete preflight and user_decisions if at least one file is deleted
-        file_store.delete_preflight(submission.submission_id)
         file_store.store_user_decisions(submission.submission_id, self.decisions)
+        # Directives depend on the selection (compiler / top-level), so always drop
+        # them here; the controller regenerates them from the new decisions.
+        file_store.delete_directives(submission.submission_id)
+        # Preflight analyses the *file set*, not the selection. Only invalidate it
+        # when files are actually removed (G29 / SUBMISSION-215). A selection-only
+        # change (compiler / top-level) leaves the report valid, so the submitter is
+        # not bounced back to Upload for a needless re-scan.
+        if self.files_to_delete:
+            file_store.delete_preflight(submission.submission_id)
         # Authoritative guard (SUBMISSION-209): never delete a file the user has
         # selected as a top-level TeX file -- that's what we're about to compile.
         # Runs under the submission row lock taken by save(), so it can't race a

--- a/submit_ce/domain/event/tests/test_set_decisions_guard.py
+++ b/submit_ce/domain/event/tests/test_set_decisions_guard.py
@@ -29,9 +29,13 @@ class _FakeStore:
         self.deleted = []
         self.user_decisions = None
         self.preflight_deleted = False
+        self.directives_deleted = False
 
     def delete_preflight(self, sid):
         self.preflight_deleted = True
+
+    def delete_directives(self, sid):
+        self.directives_deleted = True
 
     def store_user_decisions(self, sid, decisions):
         self.user_decisions = decisions
@@ -115,3 +119,38 @@ def test_protected_top_level_sources_helper():
     assert _protected_top_level_sources(decisions) == {'a.tex', 'b.tex'}
     assert _protected_top_level_sources({}) == set()
     assert _protected_top_level_sources({'sources': []}) == set()
+
+
+# --- G29 / SUBMISSION-215: preflight is invalidated only on a file-set change ---
+
+def test_execute_selection_only_keeps_preflight():
+    """Selection-only change (no deletions): preflight is preserved, but directives
+    are dropped (so they regenerate) and the decisions are persisted."""
+    s = _submission()
+    api = _FakeApi()
+    e = SetDecisions(
+        creator=s.creator,
+        decisions={'sources': [{'filename': 'main.tex'}],
+                   'process': {'compiler': 'pdflatex'}},
+        files_to_delete=[],
+    )
+    e.execute(api, s)
+    assert api._store.preflight_deleted is False   # <-- the G29 fix
+    assert api._store.directives_deleted is True
+    assert api._store.user_decisions is not None
+    assert api._store.deleted == []
+
+
+def test_execute_file_deletion_invalidates_preflight():
+    """Deleting a file DOES invalidate preflight (and drops directives)."""
+    s = _submission()
+    api = _FakeApi()
+    e = SetDecisions(
+        creator=s.creator,
+        decisions={'sources': [{'filename': 'main.tex'}]},
+        files_to_delete=['fig.png'],
+    )
+    e.execute(api, s)
+    assert api._store.preflight_deleted is True
+    assert api._store.directives_deleted is True
+    assert api._store.deleted == ['fig.png']

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -202,9 +202,13 @@ def review_files(method: str, params: MultiDict, session: Session,
         return stay_on_this_stage((rdata, status.OK, {}))
 
     elif method == 'POST':
-        has_changes = _update_preflight(params, submission_id, workspace, submitter, client)
+        # _update_preflight persists the submitted decisions and returns True only
+        # when preflight was invalidated (a file was deleted). A selection-only
+        # change (compiler / top-level) keeps preflight valid, so we fall through
+        # and advance rather than bouncing to Upload for a needless re-scan. (G29)
+        preflight_invalidated = _update_preflight(params, submission_id, workspace, submitter, client)
 
-        if has_changes:
+        if preflight_invalidated:
             return return_to_parent_stage((rdata, status.OK, {}))
         else:
             _load_or_create_directives(params, session, submission_id, token)
@@ -313,7 +317,12 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
         cmd = SetDecisions(creator=submitter, client=client,
                            decisions=new_decisions, files_to_delete=files_to_delete)
         current_app.api.save(cmd, submission_id=submission_id)
-        return True
+        # Return whether PREFLIGHT was invalidated. Only a change to the file *set*
+        # (a deletion) invalidates it, so the caller returns to Upload to re-run the
+        # scan. A selection-only change (compiler / top-level) keeps preflight valid
+        # -- SetDecisions regenerated directives but left the report -- so the caller
+        # can advance without a re-scan. (G29 / SUBMISSION-215)
+        return bool(files_to_delete)
     except InvalidEvent:
         # TODO Somehow inform the user
         return False

--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -261,7 +261,9 @@ def test_update_preflight_decisions_changed_triggers_save(
             params, 'sub1', _make_workspace('main.tex'),
             authorized_user, None,
         )
-    assert result is True
+    # G29/SUBMISSION-215: a selection-only change still saves SetDecisions, but
+    # preflight is NOT invalidated (no file deleted), so this now returns False.
+    assert result is False
     mock_save.assert_called_once()
     cmd = mock_save.call_args[0][0]
     assert cmd.decisions['texlive_version'] == '2025'
@@ -283,7 +285,9 @@ def test_update_preflight_no_existing_decisions_triggers_save(
             params, 'sub1', _make_workspace('main.tex'),
             authorized_user, None,
         )
-    assert result is True
+    # G29/SUBMISSION-215: decisions saved, but no deletion -> preflight not
+    # invalidated -> returns False.
+    assert result is False
     mock_save.assert_called_once()
 
 


### PR DESCRIPTION
Summary:

This PR eliminates unnecessary requests to refresh the preflight report. In the current code, any change on the Review Files page results in a request to refresh the preflight report. For now, we will regenerate preflight on file deletion until alternate solutions are implemented.

Details:

SetDecisions.execute deletes the preflight report only when files are actually removed (files_to_delete non-empty). A selection-only change (compiler or top-level) now keeps the report, so review_files no longer bounces the submitter to Upload for a needless re-scan. _update_preflight returns whether preflight was invalidated (bool(files_to_delete)); the POST branch advances on selection-only changes instead of returning to the parent stage.

Bonus fix: execute() now always deletes the selection-dependent directives so they regenerate. Previously nothing invalidated directives on a selection change and _load_or_create_directives only creates them when absent, so a compiler/top-level change could keep stale directives.

Tests: SetDecisions keeps preflight on selection-only changes and drops directives; deletion still invalidates it. Updated the two _update_preflight *_triggers_save tests to the new return contract.