### PR TITLE
SUBMISSION-216: Block Continue on danger-severity preflight issues

### DIFF
--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -30,7 +30,7 @@ from wtforms.validators import DataRequired
 from submit_ce.domain.uploads import Workspace, SourceFormat
 from submit_ce.domain.exceptions import InvalidEvent, SaveError
 from submit_ce.ui.controllers.util import validate_command
-from submit_ce.ui.preflight.issues import build_issue_context
+from submit_ce.ui.preflight.issues import build_issue_context, has_blocking_issues
 from submit_ce.ui.routes.flow_control import (
     stay_on_this_stage, ready_for_next, return_to_parent_stage,
     return_to_previous_stage, advance_to_current,
@@ -188,18 +188,8 @@ def review_files(method: str, params: MultiDict, session: Session,
                 title="Preflight unavailable")
             return stay_on_this_stage((rdata, status.OK, {}))
 
-        rdata['file_notes'] = dm.get_files_from_preflight(preflight_data)
-        _populate_form(form, preflight_data, user_decisions_data)
-        rdata['selected_top_level_files'] = [f for f in [form.source_file.data] if f]
-        # Surface preflight issues (SUBMISSION-210): reason-code-grouped banners
-        # + per-file badges, extracted server-side. Issue banners lead; the
-        # backend-status cards follow.
-        issue_notifications, file_issues = build_issue_context(preflight_data)
-        rdata['file_issues'] = file_issues
-        rdata['immediate_notifications'] = (
-            issue_notifications + _get_notifications(submission_id, preflight_data))
-
-        return stay_on_this_stage((rdata, status.OK, {}))
+        return _render_review_page(rdata, form, submission_id,
+                                   preflight_data, user_decisions_data)
 
     elif method == 'POST':
         # _update_preflight persists the submitted decisions and returns True only
@@ -211,15 +201,25 @@ def review_files(method: str, params: MultiDict, session: Session,
         if preflight_invalidated:
             return return_to_parent_stage((rdata, status.OK, {}))
         else:
-            _load_or_create_directives(params, session, submission_id, token)
-
-            preflight_data, user_decisions_data = _load_or_create_preflight(submission_id, params, session, token, workspace, submitter, client)
+            preflight_data, user_decisions_data = _load_or_create_preflight(
+                submission_id, params, session, token, workspace, submitter, client)
 
             if preflight_data is None:
                 alerts.flash_warning(
                     f"Preflight data is not available for this submission. {SUPPORT}",
                     title="Cannot generate directives")
                 return stay_on_this_stage((rdata, status.OK, {}))
+
+            # C1.4 (SUBMISSION-216): a danger-severity preflight issue blocks
+            # Continue -- mirrors 1.5's hasPreflightBlockers. Re-render Review
+            # Files with the issue banners instead of advancing.
+            if has_blocking_issues(preflight_data):
+                # danger issue(s) present -> re-render with the "Cannot continue"
+                # card (added by _render_review_page) instead of advancing.
+                return _render_review_page(rdata, form, submission_id,
+                                           preflight_data, user_decisions_data)
+
+            _load_or_create_directives(params, session, submission_id, token)
 
             zzrm = ZeroZeroReadMe()
             if user_decisions_data:
@@ -236,6 +236,40 @@ def review_files(method: str, params: MultiDict, session: Session,
             )
 
             return ready_for_next((rdata, status.OK, {}))
+
+
+def _render_review_page(rdata, form, submission_id, preflight_data,
+                        user_decisions_data):
+    """Populate ``rdata`` for the Review Files template and stay on the stage.
+
+    Shared by the GET path and the C1.4 danger-gate on POST so both render the
+    same page (file table, per-file badges, severity-grouped issue banners).
+    Also sets ``has_blocking_issues`` so the template can reflect the blocked
+    state. Returns a ``stay_on_this_stage`` flow-control result.
+    """
+    rdata['file_notes'] = dm.get_files_from_preflight(preflight_data)
+    _populate_form(form, preflight_data, user_decisions_data)
+    rdata['selected_top_level_files'] = [f for f in [form.source_file.data] if f]
+    # Surface preflight issues (SUBMISSION-210): reason-code-grouped banners
+    # + per-file badges, extracted server-side. Issue banners lead; the
+    # backend-status cards follow.
+    issue_notifications, file_issues = build_issue_context(preflight_data)
+    rdata['file_issues'] = file_issues
+    rdata['has_blocking_issues'] = any(
+        n.get('severity') == 'danger' for n in issue_notifications)
+    if rdata['has_blocking_issues']:
+        # Persistent danger card that explains why Continue is disabled. Shown on
+        # every render while blocked (GET and the POST gate), not just after a
+        # submit attempt -- the button is disabled, so a flash would never appear.
+        # (C1.4 / SUBMISSION-216)
+        issue_notifications = [{
+            'title': 'Cannot continue',
+            'severity': 'danger',
+            'body': 'Please resolve the highlighted problem(s) before you can continue.',
+        }] + issue_notifications
+    rdata['immediate_notifications'] = (
+        issue_notifications + _get_notifications(submission_id, preflight_data))
+    return stay_on_this_stage((rdata, status.OK, {}))
 
 
 def _get_zzrm_data(workspace: Workspace, submission_id: str) -> Optional[dict]:

--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -160,6 +160,39 @@ def test_review_files_post_no_changes_stores_zzrm_and_advances(
     assert zzrm_calls[0].kwargs['submission_id'] == str(sub_files_tex.submission_id)
 
 
+def test_review_files_post_danger_issue_blocks_continue(
+        app, authorized_client, sub_files_tex, mocker):
+    """C1.4/SUBMISSION-216: a danger-severity preflight issue blocks Continue --
+    the controller stays on the stage (200, not a 303 redirect), renders the
+    'Cannot continue' card, and does not generate directives or store the
+    00README."""
+    url = f"/{sub_files_tex.submission_id}/review_files"
+    csrf = _get_csrf(authorized_client, url, mocker)
+
+    mocker.patch.object(review, '_update_preflight', return_value=False)
+    # A real danger payload so the gate and the rendered card agree
+    # (conflicting_file_type is a danger code).
+    danger_preflight = {
+        'tex_files': [],
+        'detected_toplevel_files': [
+            {'filename': 'main.tex',
+             'issues': [{'key': 'conflicting_file_type', 'info': ''}]}],
+    }
+    mocker.patch.object(review, '_load_or_create_preflight',
+                        return_value=(danger_preflight, {'sources': []}))
+    mock_load_dir = mocker.patch.object(review, '_load_or_create_directives')
+    mock_save = mocker.patch.object(app.api, 'save',
+                                    return_value=(MagicMock(), []))
+
+    resp = authorized_client.post(url, data={'csrf_token': csrf, 'action': 'next'})
+
+    assert resp.status_code == status.OK           # stayed; did not advance
+    mock_load_dir.assert_not_called()              # no directives generated
+    assert b'Cannot continue' in resp.data          # persistent danger card rendered
+    assert not any(c.args and isinstance(c.args[0], review.StoreZzrm)
+                   for c in mock_save.call_args_list)
+
+
 def _make_workspace(*paths):
     """Build a stand-in workspace whose `.files` carry the given paths."""
     ws = MagicMock()

--- a/submit_ce/ui/preflight/issues.py
+++ b/submit_ce/ui/preflight/issues.py
@@ -141,3 +141,14 @@ def build_issue_context(
         notifications.append(notification)
 
     return notifications, file_issues
+
+
+def has_blocking_issues(preflight_data: Optional[dict]) -> bool:
+    """Return True if any surfaced preflight issue is ``danger`` severity.
+
+    Mirrors 1.5's ``hasPreflightBlockers``: a ``danger`` issue must block the
+    submitter from continuing past Review Files. Silent/warning/info issues do
+    not block. (SUBMISSION-216 / C1.4)
+    """
+    notifications, _ = build_issue_context(preflight_data)
+    return any(n.get("severity") == "danger" for n in notifications)

--- a/submit_ce/ui/preflight/tests/test_issues.py
+++ b/submit_ce/ui/preflight/tests/test_issues.py
@@ -5,7 +5,39 @@ import pytest
 from submit_ce.ui.preflight.issues import (
     PREFLIGHT_ISSUE_DIRECTIVES,
     build_issue_context,
+    has_blocking_issues,
 )
+
+
+def _pf(*keys):
+    """Minimal preflight payload carrying the given issue codes on the top-level."""
+    return {
+        "detected_toplevel_files": [
+            {"filename": "main.tex",
+             "issues": [{"key": k, "info": ""} for k in keys]}
+        ],
+        "tex_files": [],
+    }
+
+
+# --- SUBMISSION-216 / C1.4: has_blocking_issues (danger blocks Continue) ---------
+
+def test_has_blocking_issues_true_for_danger_code():
+    assert has_blocking_issues(_pf("conflicting_file_type")) is True
+
+
+def test_has_blocking_issues_false_for_warning_only():
+    assert has_blocking_issues(_pf("file_not_found")) is False
+
+
+def test_has_blocking_issues_false_for_silent_or_empty_or_none():
+    assert has_blocking_issues(_pf("issue_in_subfile")) is False  # silent
+    assert has_blocking_issues(_pf()) is False
+    assert has_blocking_issues(None) is False
+
+
+def test_has_blocking_issues_true_when_danger_mixed_with_warning():
+    assert has_blocking_issues(_pf("file_not_found", "conflicting_file_type")) is True
 
 
 def test_directives_cover_every_producer_issue_type():


### PR DESCRIPTION
Summary: Block submitter from continuing on to next step when danger-severity preflight issues exist.

Details:

Review Files no longer advances while a danger-severity preflight issue is
present (mirrors 1.5's hasPreflightBlockers). Adds has_blocking_issues() to
preflight/issues.py; review.py POST returns stay_on_this_stage instead of
ready_for_next and re-renders via a shared _render_review_page helper that
prepends a persistent red "Cannot continue" card.

**Continue stays enabled on purpose**: deletions ride the Continue POST (processed
and bounced to Upload before the gate), so disabling it would trap the
corrective action.

Scope: the danger-issue blocker only; complements existing structural gates
(stage needs directives -> a viable top-level) and is a subset of G20.

Tests: has_blocking_issues (danger true; warning/silent/empty/None false);
controller POST with a danger issue stays (200), renders the card, and skips
the directives + 00README write.

Question: 

The Continue button is left enabled in case there are deletions that the submitter wants to affect. In some cases, where the user must fix and upload a file, the user will need to return to the Upload Files page. Should we add a note to the 'Cannot Continue' card, and/or disable the continue button and force submitter to make corrections on the Upload Files page?

<img width="1044" height="1579" alt="GatingOnUpdatedSeverity-Screenshot 2026-08-05 at 11 51 07 AM" src="https://github.com/user-attachments/assets/23e08b97-6c13-422e-b603-0097c7a68be6" />

Note: There is a ticket to reorganize and clean up the cards.