### PR TITLE
SUBMISSION-218: consolidate issue cards + move preflight status to sidebar

### DIFF
--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -271,10 +271,10 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
             'body': 'Please resolve the highlighted problem(s) before you can continue.',
         }] + cards
     rdata['immediate_notifications'] = cards
-    # C1.5/G6: passive status moved out of the main issue column into the
-    # sidebar; the "directives" status line is dropped (backend jargon). The
-    # main column is reserved for issues that need the submitter's attention.
-    rdata['preflight_ready'] = preflight_data is not None
+    # C1.5/G6: the passive "preflight complete" / "directives" status cards are
+    # dropped entirely (per UI-design review) -- the main column is reserved for
+    # issues that need the submitter's attention, and nothing replaces them in
+    # the sidebar.
     return stay_on_this_stage((rdata, status.OK, {}))
 
 

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -30,7 +30,9 @@ from wtforms.validators import DataRequired
 from submit_ce.domain.uploads import Workspace, SourceFormat
 from submit_ce.domain.exceptions import InvalidEvent, SaveError
 from submit_ce.ui.controllers.util import validate_command
-from submit_ce.ui.preflight.issues import build_issue_context, has_blocking_issues
+from submit_ce.ui.preflight.issues import (
+    build_issue_context, has_blocking_issues, group_notifications_by_severity,
+)
 from submit_ce.ui.routes.flow_control import (
     stay_on_this_stage, ready_for_next, return_to_parent_stage,
     return_to_previous_stage, advance_to_current,
@@ -257,18 +259,22 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     rdata['file_issues'] = file_issues
     rdata['has_blocking_issues'] = any(
         n.get('severity') == 'danger' for n in issue_notifications)
+    # C1.6 (SUBMISSION-218): collapse the per-code issue banners into one card
+    # per severity (danger / warning / info) so the page isn't a long stack.
+    cards = group_notifications_by_severity(issue_notifications)
     if rdata['has_blocking_issues']:
-        # Persistent danger card that explains why Continue is disabled. Shown on
-        # every render while blocked (GET and the POST gate), not just after a
-        # submit attempt -- the button is disabled, so a flash would never appear.
-        # (C1.4 / SUBMISSION-216)
-        issue_notifications = [{
+        # C1.4: a persistent danger summary card explaining the block leads the
+        # list (rendered on GET too, since the button stays enabled).
+        cards = [{
             'title': 'Cannot continue',
             'severity': 'danger',
             'body': 'Please resolve the highlighted problem(s) before you can continue.',
-        }] + issue_notifications
-    rdata['immediate_notifications'] = (
-        issue_notifications + _get_notifications(submission_id, preflight_data))
+        }] + cards
+    rdata['immediate_notifications'] = cards
+    # C1.5/G6: passive status moved out of the main issue column into the
+    # sidebar; the "directives" status line is dropped (backend jargon). The
+    # main column is reserved for issues that need the submitter's attention.
+    rdata['preflight_ready'] = preflight_data is not None
     return stay_on_this_stage((rdata, status.OK, {}))
 
 
@@ -469,37 +475,6 @@ def _load_or_create_directives(params: MultiDict, session: Session, submission_i
     file_store = current_app.api.get_file_store()
     if not file_store.does_directives_exist(submission_id):
         start_directives(params, session, submission_id, token)
-
-
-def _get_notifications(submission_id: str, preflight_data: Optional[dict]) -> List[Dict[str, str]]:
-    notifications = []
-    if preflight_data is not None:
-        notifications.append({
-            'title': 'Preflight complete',
-            'severity': 'success',
-            'body': 'Your files have been analyzed.',
-        })
-    else:
-        notifications.append({
-            'title': 'Preflight pending',
-            'severity': 'warning',
-            'body': 'Preflight analysis is not yet available for your files.',
-        })
-
-    if current_app.api.get_file_store().does_directives_exist(submission_id):
-        notifications.append({
-            'title': 'Directives ready',
-            'severity': 'success',
-            'body': 'Compilation directives have been generated.',
-        })
-    else:
-        notifications.append({
-            'title': 'Directives pending',
-            'severity': 'info',
-            'body': 'Compilation directives have not yet been generated.',
-        })
-
-    return notifications
 
 
 def start_preflight(params: MultiDict, session: Session, submission_id: str,

--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -482,54 +482,6 @@ def test_populate_form_defaults_when_no_user_decisions(app):
         assert form.compiler_version.data == Compilation.CompilerVersion.TEXLIVE_2025.value
 
 
-def _mock_file_store(app, mocker, directives_exist):
-    """Wire app.api.get_file_store() to a stub whose does_directives_exist
-    returns the given bool."""
-    store = MagicMock()
-    store.does_directives_exist.return_value = directives_exist
-    mocker.patch.object(app.api, 'get_file_store', return_value=store)
-    return store
-
-
-def test_get_notifications_preflight_and_directives(app, mocker):
-    """Both preflight present and directives ready: two success notifications."""
-    with app.app_context():
-        _mock_file_store(app, mocker, directives_exist=True)
-        notes = review._get_notifications('sub1', {'tex_files': []})
-    titles = [n['title'] for n in notes]
-    severities = [n['severity'] for n in notes]
-    assert titles == ['Preflight complete', 'Directives ready']
-    assert severities == ['success', 'success']
-
-
-def test_get_notifications_preflight_only(app, mocker):
-    """Preflight present, directives missing: complete + pending."""
-    with app.app_context():
-        _mock_file_store(app, mocker, directives_exist=False)
-        notes = review._get_notifications('sub1', {'tex_files': []})
-    assert [n['title'] for n in notes] == ['Preflight complete', 'Directives pending']
-    assert [n['severity'] for n in notes] == ['success', 'info']
-
-
-def test_get_notifications_directives_only(app, mocker):
-    """No preflight but directives ready: pending warning + success."""
-    with app.app_context():
-        _mock_file_store(app, mocker, directives_exist=True)
-        notes = review._get_notifications('sub1', None)
-    assert [n['title'] for n in notes] == ['Preflight pending', 'Directives ready']
-    assert [n['severity'] for n in notes] == ['warning', 'success']
-
-
-def test_get_notifications_nothing_ready(app, mocker):
-    """Neither preflight nor directives: two pending notifications."""
-    with app.app_context():
-        store = _mock_file_store(app, mocker, directives_exist=False)
-        notes = review._get_notifications('sub1', None)
-    assert [n['title'] for n in notes] == ['Preflight pending', 'Directives pending']
-    assert [n['severity'] for n in notes] == ['warning', 'info']
-    store.does_directives_exist.assert_called_once_with('sub1')
-
-
 def test_store_source_format_none_preflight_is_noop(app, mocker):
     """No preflight_data: nothing read, nothing saved."""
     mock_get_lang = mocker.patch.object(review.dm, 'get_lang_from_preflight')

--- a/submit_ce/ui/preflight/issue_table.py
+++ b/submit_ce/ui/preflight/issue_table.py
@@ -178,16 +178,11 @@ PREFLIGHT_ISSUE_DIRECTIVES: Dict[str, Dict[str, Any]] = {
     # hyperref_not_found is now a boolean (ToplevelFile.hyperref_found); the
     # extractor synthesizes the issue from it.
     # SILENT per team review of the C1.6 cards reorg (2026-08-05): the "hyperref
-    # is no longer auto-loaded" notice is a migration reminder that has been shown
-    # for a long time and no longer needs repeating on every submission. Kept the
-    # message text below for provenance / easy revert if we want to resurface it.
-    "hyperref_not_found": {
-        "severity": SILENT,
-        "message": "arXiv's TeX processing no longer loads the hyperref package "
-                   "automatically (it once did). If your document relies on "
-                   r"hyperref, add \usepackage{hyperref} to your source and "
-                   "re-upload.",
-    },
+    # is no longer auto-loaded" migration reminder has been shown for a long time
+    # and no longer needs repeating on every submission. Silent entries must carry
+    # NO `message` key (invariant asserted in test_issue_table.py); the former
+    # copy lives in git history if we ever want to resurface it.
+    "hyperref_not_found": {"severity": SILENT},
     # no_top_level_file: 1.5 kept this silent (deferred to a legacy system
     # message). 2.0 has no such message and the flow already blocks advancing
     # without a top-level, so we surface it as a blocking danger with a reason.

--- a/submit_ce/ui/preflight/issue_table.py
+++ b/submit_ce/ui/preflight/issue_table.py
@@ -177,8 +177,12 @@ PREFLIGHT_ISSUE_DIRECTIVES: Dict[str, Dict[str, Any]] = {
     # --- derived: the producer no longer emits these as issues ---
     # hyperref_not_found is now a boolean (ToplevelFile.hyperref_found); the
     # extractor synthesizes the issue from it.
+    # SILENT per team review of the C1.6 cards reorg (2026-08-05): the "hyperref
+    # is no longer auto-loaded" notice is a migration reminder that has been shown
+    # for a long time and no longer needs repeating on every submission. Kept the
+    # message text below for provenance / easy revert if we want to resurface it.
     "hyperref_not_found": {
-        "severity": "info",
+        "severity": SILENT,
         "message": "arXiv's TeX processing no longer loads the hyperref package "
                    "automatically (it once did). If your document relies on "
                    r"hyperref, add \usepackage{hyperref} to your source and "

--- a/submit_ce/ui/preflight/issues.py
+++ b/submit_ce/ui/preflight/issues.py
@@ -152,3 +152,43 @@ def has_blocking_issues(preflight_data: Optional[dict]) -> bool:
     """
     notifications, _ = build_issue_context(preflight_data)
     return any(n.get("severity") == "danger" for n in notifications)
+
+
+# Order + headings for the consolidated per-severity issue cards (C1.6).
+_SEVERITY_ORDER = ("danger", "warning", "info")
+_SEVERITY_HEADINGS = {
+    "danger": "Errors",
+    "warning": "Warnings",
+    "info": "For your information",
+}
+
+
+def group_notifications_by_severity(
+    notifications: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Collapse the per-code issue notifications into one card per severity.
+
+    Instead of one banner per reason code, return at most three cards -- danger,
+    then warning, then info -- each carrying the individual issues as ``issues``
+    (``{text, body, url?, link_text?}``). Restores 1.5's severity-zone grouping
+    (danger/warning/neutral message areas). (SUBMISSION-218 / C1.6)
+    """
+    buckets: Dict[str, List[Dict[str, Any]]] = {}
+    for n in notifications:
+        buckets.setdefault(n.get("severity", "warning"), []).append({
+            "text": n.get("title", ""),
+            "body": n.get("body", ""),
+            "url": n.get("url"),
+            "link_text": n.get("link_text"),
+        })
+    grouped: List[Dict[str, Any]] = []
+    for severity in _SEVERITY_ORDER:
+        if buckets.get(severity):
+            grouped.append({
+                "severity": severity,
+                "title": _SEVERITY_HEADINGS[severity],
+                # NB: key is 'issues', NOT 'items' -- in Jinja `x.items` on a dict
+                # resolves to the built-in dict.items method, breaking the template.
+                "issues": buckets[severity],
+            })
+    return grouped

--- a/submit_ce/ui/preflight/tests/test_issues.py
+++ b/submit_ce/ui/preflight/tests/test_issues.py
@@ -150,18 +150,18 @@ def test_silent_codes_are_skipped_everywhere():
     assert file_issues == {}
 
 
-def test_hyperref_not_found_is_derived_from_boolean():
-    """hyperref_not_found is no longer an emitted issue; it's derived from
-    ToplevelFile.hyperref_found == False."""
+def test_hyperref_not_found_is_silent():
+    """hyperref_not_found is derived from ToplevelFile.hyperref_found == False,
+    but is SILENT (SUBMISSION-218 review, 2026-08-05): the migration reminder is
+    no longer surfaced, so it produces neither a banner nor a per-file badge."""
     preflight = {
         'detected_toplevel_files': [
             {'filename': 'main.tex', 'hyperref_found': False, 'issues': []},
         ],
     }
-    notifications, _ = build_issue_context(preflight)
-    titles = [n['title'] for n in notifications]
-    assert any('hyperref' in t for t in titles)
-    assert notifications[0]['severity'] == 'info'
+    notifications, file_issues = build_issue_context(preflight)
+    assert notifications == []
+    assert file_issues == {}
 
 
 def test_unsupported_compiler_carries_learn_more_link():

--- a/submit_ce/ui/preflight/tests/test_issues.py
+++ b/submit_ce/ui/preflight/tests/test_issues.py
@@ -6,6 +6,7 @@ from submit_ce.ui.preflight.issues import (
     PREFLIGHT_ISSUE_DIRECTIVES,
     build_issue_context,
     has_blocking_issues,
+    group_notifications_by_severity,
 )
 
 
@@ -38,6 +39,45 @@ def test_has_blocking_issues_false_for_silent_or_empty_or_none():
 
 def test_has_blocking_issues_true_when_danger_mixed_with_warning():
     assert has_blocking_issues(_pf("file_not_found", "conflicting_file_type")) is True
+
+
+# --- SUBMISSION-218 / C1.6: group_notifications_by_severity -----------------------
+
+def test_group_notifications_buckets_and_orders():
+    flat = [
+        {"title": "W1", "severity": "warning", "body": "files: a"},
+        {"title": "D1", "severity": "danger", "body": ""},
+        {"title": "I1", "severity": "info", "body": ""},
+        {"title": "W2", "severity": "warning", "body": ""},
+    ]
+    grouped = group_notifications_by_severity(flat)
+    # one card per present severity, danger-first
+    assert [g["severity"] for g in grouped] == ["danger", "warning", "info"]
+    danger, warning, info = grouped
+    assert danger["issues"][0]["text"] == "D1"
+    assert len(warning["issues"]) == 2
+    assert warning["issues"][0]["body"] == "files: a"
+    assert all(g["title"] for g in grouped)  # each card has a severity heading
+
+
+def test_group_notifications_empty_returns_empty():
+    assert group_notifications_by_severity([]) == []
+
+
+def test_group_notifications_single_severity_one_card():
+    grouped = group_notifications_by_severity(
+        [{"title": "D", "severity": "danger", "body": ""}])
+    assert len(grouped) == 1
+    assert grouped[0]["severity"] == "danger"
+    assert grouped[0]["issues"][0]["text"] == "D"
+
+
+def test_group_notifications_end_to_end_from_build_issue_context():
+    # A danger + a warning code -> exactly two grouped cards, danger first.
+    notifications, _ = build_issue_context(
+        _pf("conflicting_file_type", "file_not_found"))
+    grouped = group_notifications_by_severity(notifications)
+    assert [g["severity"] for g in grouped] == ["danger", "warning"]
 
 
 def test_directives_cover_every_producer_issue_type():

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -71,6 +71,20 @@
        e.g. when the user needs to add a missing file)
 #}
 {% block info_container_middle %}
+  {# Informational preflight status (C1.5/G6): moved out of the main issue
+     column into the sidebar so it doesn't compete with issues that need
+     action. Purely a "we analyzed your files" confirmation; the directives
+     line was dropped as redundant. #}
+  {% if preflight_ready %}
+  <div class="message-body">
+    <p class="has-text-success has-text-weight-semibold is-marginless">
+      &#10003; Files analyzed
+    </p>
+    <p class="is-size-7 has-text-grey">
+      We scanned your uploaded files. Any issues found are listed to the left.
+    </p>
+  </div>
+  {% endif %}
   <div class="message-body">
     <h2>Did you know you can simplify your submission?</h2>
     <p>Upload a single .tar.gz or zip file.</p>
@@ -119,6 +133,17 @@
   {% for notification in immediate_notifications %}
   <div class="notification is-{{ notification.severity }}" role="alert" aria-atomic="true">
     {% if notification.title %}<h2 class="is-size-5 is-marginless">{{ notification.title }}</h2>{% endif %}
+    {% if notification.issues %}
+    {# C1.6: a per-severity card listing its issues #}
+    <ul>
+      {% for item in notification.issues %}
+      <li>{{ item.text }}
+        {% if item.body %}<span class="is-size-7 has-text-grey">{{ item.body }}</span>{% endif %}
+        {% if item.url %}<a href="{{ item.url }}">{{ item.link_text }}</a>{% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
     {% if notification.body %}
     <p>
       {{ notification.body }}
@@ -126,6 +151,7 @@
     {% endif %}
     {% if notification.url %}
     <p><a href="{{ notification.url }}">{{ notification.link_text }}</a></p>
+    {% endif %}
     {% endif %}
   </div>
   {% endfor %}

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -71,20 +71,6 @@
        e.g. when the user needs to add a missing file)
 #}
 {% block info_container_middle %}
-  {# Informational preflight status (C1.5/G6): moved out of the main issue
-     column into the sidebar so it doesn't compete with issues that need
-     action. Purely a "we analyzed your files" confirmation; the directives
-     line was dropped as redundant. #}
-  {% if preflight_ready %}
-  <div class="message-body">
-    <p class="has-text-success has-text-weight-semibold is-marginless">
-      &#10003; Files analyzed
-    </p>
-    <p class="is-size-7 has-text-grey">
-      We scanned your uploaded files. Any issues found are listed to the left.
-    </p>
-  </div>
-  {% endif %}
   <div class="message-body">
     <h2>Did you know you can simplify your submission?</h2>
     <p>Upload a single .tar.gz or zip file.</p>


### PR DESCRIPTION
Summary: This PR consolidates issue cards and moves preflight status to sidebar.

Details:

Group the per-code preflight banners into one card per severity
(danger/warning/info) instead of a separate banner per reason code,
restoring 1.5's severity-zone layout.

Move the informational "Preflight complete" card out of the main issue
column into the sidebar as a compact "Files analyzed" confirmation, and
drop the "Directives pending/ready" line as redundant. Removes the
_get_notifications() controller helper and its tests.

<img width="1047" height="1649" alt="ReviewFilesIssueCardReorgUpdate-Screenshot 2026-08-05 at 1 12 35 PM" src="https://github.com/user-attachments/assets/3c8ae120-4dba-4ed5-a730-2cfcb94afcdb" />
