### PR TITLE
SUBMISSION-219: consolidate per-file Review Files context

### DIFF
--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -33,6 +33,7 @@ from submit_ce.ui.controllers.util import validate_command
 from submit_ce.ui.preflight.issues import (
     build_issue_context, has_blocking_issues, group_notifications_by_severity,
 )
+from submit_ce.ui.preflight.file_context import build_file_rows
 from submit_ce.ui.routes.flow_control import (
     stay_on_this_stage, ready_for_next, return_to_parent_stage,
     return_to_previous_stage, advance_to_current,
@@ -249,14 +250,24 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     Also sets ``has_blocking_issues`` so the template can reflect the blocked
     state. Returns a ``stay_on_this_stage`` flow-control result.
     """
-    rdata['file_notes'] = dm.get_files_from_preflight(preflight_data)
     _populate_form(form, preflight_data, user_decisions_data)
-    rdata['selected_top_level_files'] = [f for f in [form.source_file.data] if f]
+    selected_top_level_files = [f for f in [form.source_file.data] if f]
+    rdata['selected_top_level_files'] = selected_top_level_files
     # Surface preflight issues (SUBMISSION-210): reason-code-grouped banners
     # + per-file badges, extracted server-side. Issue banners lead; the
     # backend-status cards follow.
     issue_notifications, file_issues = build_issue_context(preflight_data)
     rdata['file_issues'] = file_issues
+    # F0 (SUBMISSION-219): fold the per-file badges and the top-level / README
+    # flags into each file row so the template renders fields from one object
+    # instead of computing them inline (and re-deriving them from separate
+    # file_issues / selected_top_level_files parameters). Gives C3 a single
+    # per-file object to extend with used/unused + delete defaults later.
+    rdata['file_notes'] = build_file_rows(
+        dm.get_files_from_preflight(preflight_data),
+        file_issues,
+        selected_top_level_files,
+    )
     rdata['has_blocking_issues'] = any(
         n.get('severity') == 'danger' for n in issue_notifications)
     # C1.6 (SUBMISSION-218): collapse the per-code issue banners into one card

--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -1,0 +1,55 @@
+"""Assemble the per-file rows for the Review Files table. [SUBMISSION-219 / F0]
+
+The ``display_preflight_tree`` macro used to compute everything about a file
+inline: it looked the badges up in a separate ``file_issues`` dict and decided
+"is this the 00README / a selected top-level file?" with string comparisons
+against extra template parameters. C1 (issue badges) and C3 (file-use status,
+delete defaults) both need to write that same "Auto-detected Notes" cell, so
+without a single seam they conflict in the controller and the template.
+
+This module provides that seam: it folds the per-file issue badges and the
+top-level / README flags into each file object, so the template renders
+fields from one object instead of computing them. C3 can extend the object
+(used/unused, delete defaults, image size) without touching Jinja.
+
+Pure transform -- no I/O.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+# The build-directives file: not a deletion candidate, and it gets a dedicated
+# note rather than a usage line.
+README_FILENAME = "00README.json"
+
+
+def build_file_rows(
+    file_notes: List[Dict[str, Any]],
+    file_issues: Optional[Dict[str, List[Dict[str, str]]]],
+    selected_top_level_files: List[str],
+) -> List[Dict[str, Any]]:
+    """Return the preflight file list enriched for the Review Files table.
+
+    Each row keeps its preflight keys (``filename`` and, where present,
+    ``used_by`` / ``used_by_tex`` / ``used_by_bib``) and gains:
+
+    * ``badges`` -- per-file issue badges ``[{severity, label}, ...]`` (empty
+      list when the file has none);
+    * ``is_readme`` -- ``True`` for ``00README.json`` (build-directives file);
+    * ``is_toplevel`` -- ``True`` when the file is a selected top-level TeX file.
+
+    ``is_readme`` / ``is_toplevel`` drive both the disabled delete checkbox and
+    the usage note; ``badges`` render before the note. The input dicts are not
+    mutated.
+    """
+    issues = file_issues or {}
+    top_levels = set(selected_top_level_files or [])
+    rows: List[Dict[str, Any]] = []
+    for note in file_notes:
+        row = dict(note)
+        filename = row.get("filename")
+        row["badges"] = issues.get(filename) or []
+        row["is_readme"] = filename == README_FILENAME
+        row["is_toplevel"] = filename in top_levels
+        rows.append(row)
+    return rows

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -1,0 +1,58 @@
+"""Tests for :mod:`submit_ce.ui.preflight.file_context`. [SUBMISSION-219 / F0]"""
+
+from submit_ce.ui.preflight.file_context import build_file_rows
+
+
+def _notes():
+    return [
+        {"filename": "00README.json"},
+        {"filename": "main.tex"},
+        {"filename": "refs.bib", "used_by_bib": ["main.tex"]},
+    ]
+
+
+def test_flags_readme_and_toplevel():
+    rows = build_file_rows(_notes(), {}, ["main.tex"])
+    by_name = {r["filename"]: r for r in rows}
+    assert by_name["00README.json"]["is_readme"] is True
+    assert by_name["00README.json"]["is_toplevel"] is False
+    assert by_name["main.tex"]["is_toplevel"] is True
+    assert by_name["main.tex"]["is_readme"] is False
+    assert by_name["refs.bib"]["is_readme"] is False
+    assert by_name["refs.bib"]["is_toplevel"] is False
+
+
+def test_badges_default_to_empty_list_and_attach_by_filename():
+    issues = {"main.tex": [{"severity": "danger", "label": "conflicting file type"}]}
+    rows = build_file_rows(_notes(), issues, [])
+    by_name = {r["filename"]: r for r in rows}
+    assert by_name["main.tex"]["badges"] == [
+        {"severity": "danger", "label": "conflicting file type"}]
+    # Files with no issue get an empty list, never None, so the template can
+    # test truthiness uniformly.
+    assert by_name["refs.bib"]["badges"] == []
+    assert by_name["00README.json"]["badges"] == []
+
+
+def test_preflight_keys_are_preserved():
+    rows = build_file_rows(_notes(), {}, [])
+    refs = next(r for r in rows if r["filename"] == "refs.bib")
+    assert refs["used_by_bib"] == ["main.tex"]
+
+
+def test_input_dicts_are_not_mutated():
+    notes = _notes()
+    build_file_rows(notes, {"main.tex": [{"severity": "danger", "label": "x"}]},
+                    ["main.tex"])
+    # Original notes must be untouched (no badges/is_readme/is_toplevel leaked in).
+    assert all("badges" not in n and "is_readme" not in n
+               and "is_toplevel" not in n for n in notes)
+
+
+def test_none_issues_and_none_selection_are_safe():
+    rows = build_file_rows(_notes(), None, None)
+    assert all(r["badges"] == [] and r["is_toplevel"] is False for r in rows)
+
+
+def test_empty_notes_returns_empty():
+    assert build_file_rows([], {}, ["main.tex"]) == []

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -7,24 +7,29 @@
 {% endblock addl_head %}
 
 {# Renders one row of the Review Files table for a preflight-detected file,
-   or recurses into a subdirectory listing. The third argument
-   ``top_level_filenames`` is the list of currently-selected top-level TeX
-   files (one or more) so we can render "Used: top-level file" for each and
-   disable its delete checkbox -- a selected top-level file is what we're about
-   to compile and must not be deletable here (SUBMISSION-209).
-   ``file_issues`` maps filename -> per-file preflight issue badges (SUBMISSION-210).
-   00README.json likewise gets a dedicated label and a disabled delete
-   checkbox -- it's a build-directives file, not a candidate for deletion. #}
-{% macro display_preflight_tree(key, item, top_level_filenames, file_issues) %}
+   or recurses into a subdirectory listing. Each file ``item`` is a per-file
+   context object assembled server-side by ``build_file_rows`` (SUBMISSION-219 /
+   F0), so this macro renders fields instead of computing them inline:
+     ``item.badges``     -- per-file preflight issue badges (SUBMISSION-210);
+     ``item.is_toplevel``-- a currently-selected top-level TeX file: rendered as
+                            "Used: top-level file" with its delete checkbox
+                            disabled, since it's what we're about to compile and
+                            must not be deletable here (SUBMISSION-209);
+     ``item.is_readme``  -- the 00README.json build-directives file: a dedicated
+                            label and a disabled delete checkbox, not a deletion
+                            candidate.
+   C3 will extend this same object (used/unused, delete defaults) without
+   touching this macro. #}
+{% macro display_preflight_tree(key, item) %}
   {% if 'filename' in item %}
   <tr>
     <td class="has-text-centered">
       <input type="hidden" name="all_files" value="{{ item.filename }}">
-      {% if item.filename == '00README.json' %}
+      {% if item.is_readme %}
         <input type="checkbox" name="selected_files" value="{{ item.filename }}"
                disabled data-lock="permanent"
                title="00README.json contains build directives and cannot be deleted from this step">
-      {% elif item.filename in top_level_filenames %}
+      {% elif item.is_toplevel %}
         <input type="checkbox" name="selected_files" value="{{ item.filename }}"
                disabled
                title="This is a selected top-level TeX file and cannot be deleted here. Remove it from the Top-Level TeX selection first.">
@@ -36,13 +41,13 @@
     <td>
       {# Preflight issue badges (SUBMISSION-210), severity-colored, before the
          auto-detected usage note. #}
-      {% set file_issue_list = file_issues.get(item.filename) if file_issues else None %}
+      {% set file_issue_list = item.badges %}
       {% if file_issue_list %}
         {% for issue in file_issue_list %}<span class="tag is-{{ issue.severity }}">{{ issue.label }}</span> {% endfor %}<br>
       {% endif %}
-      {% if item.filename == '00README.json' %}
+      {% if item.is_readme %}
         Build directives file
-      {% elif item.filename in top_level_filenames %}
+      {% elif item.is_toplevel %}
         Used: top-level file
       {% else %}
         {% if item.used_by %}Used by: {{ item.used_by | join(', ') }}<br>{% endif %}
@@ -54,7 +59,7 @@
   {% else %}
   <tr><td colspan="3"><em>{{ key }}/</em></td></tr>
   {% for k, subitem in item.items() %}
-    {{ display_preflight_tree(k, subitem, top_level_filenames, file_issues) }}
+    {{ display_preflight_tree(k, subitem) }}
   {% endfor %}
   {% endif %}
 {% endmacro %}
@@ -232,7 +237,7 @@
       </thead>
       <tbody>
         {% for k, item in (file_notes | group_preflight_files).items() %}
-          {{ display_preflight_tree(k, item, selected_top_level_files, file_issues) }}
+          {{ display_preflight_tree(k, item) }}
         {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
Summary: 

Centralize building structure to collect per-file information to be displayed in the file list. In 1.5, this was done on client side using Javascript.

Detail:

Pure refactor. Introduces build_file_rows() to fold per-file issue badges and the top-level/README flags into each file object, so the display_preflight_tree macro renders fields from one per-file object instead of computing them inline. Rendered HTML is byte-identical (verified). Sets up file list to extend the per-file object with used/unused + delete defaults. Stacked on #103. Nothing displayed in UI yet. Coming soon!