### PR TITLE
SUBMISSION-172: show image size + highlight oversized images 

### DIFF
--- a/submit_ce/implementations/compile/directive_manager.py
+++ b/submit_ce/implementations/compile/directive_manager.py
@@ -72,4 +72,21 @@ class DirectiveManager:
                     files.setdefault(used, {'filename': used})
                     files[used].setdefault(ref_key, []).append(tex_name)
 
+        # Carry per-image size metadata so the Review Files table can show
+        # dimensions and highlight oversized images (SUBMISSION-172).
+        # is_oversized is authoritative from preflight -- it already encodes
+        # "megapixels > threshold AND not pdftex-fast-copy", so a fast-copy
+        # image (e.g. JPEG, clean RGB PNG) is never oversized regardless of
+        # size. We surface these fields; we do not recompute the flag.
+        for img in preflight_data.get('image_files', []):
+            filename = img.get('filename')
+            if not filename:
+                continue
+            entry = files.setdefault(filename, {'filename': filename})
+            entry['width'] = img.get('width')
+            entry['height'] = img.get('height')
+            entry['megapixels'] = img.get('megapixels')
+            entry['file_bytes'] = img.get('file_bytes')
+            entry['is_oversized'] = img.get('is_oversized', False)
+
         return list(files.values())

--- a/submit_ce/implementations/tests/test_directive_manager.py
+++ b/submit_ce/implementations/tests/test_directive_manager.py
@@ -81,6 +81,41 @@ def test_get_files_from_preflight_builds_used_by_refs():
     assert by_name["refs.bib"]["used_by_bib"] == ["main.tex"]
 
 
+def test_get_files_from_preflight_carries_image_size_fields():
+    """Image size metadata rides through onto the file row (SUBMISSION-172). is_oversized is taken verbatim from preflight -- it already encodes
+    "large AND not fast-copy" -- so a large fast-copy image is NOT oversized
+    while a same-size slow-copy image is."""
+    preflight = {
+        "image_files": [
+            {"filename": "big_slow.png", "width": 7000, "height": 7000,
+             "megapixels": 49.0, "file_bytes": 12_000_000,
+             "is_oversized": True, "pdftex-fast-copy": False},
+            {"filename": "big_fast.png", "width": 7000, "height": 7000,
+             "megapixels": 49.0, "file_bytes": 4_000_000,
+             "is_oversized": False, "pdftex-fast-copy": True},
+            {"filename": "small.png", "width": 1000, "height": 1000,
+             "megapixels": 1.0, "file_bytes": 200_000,
+             "is_oversized": False, "pdftex-fast-copy": True},
+        ],
+    }
+    by_name = {f["filename"]: f for f in dm.get_files_from_preflight(preflight)}
+
+    assert by_name["big_slow.png"]["megapixels"] == 49.0
+    assert by_name["big_slow.png"]["width"] == 7000
+    assert by_name["big_slow.png"]["height"] == 7000
+    assert by_name["big_slow.png"]["file_bytes"] == 12_000_000
+    assert by_name["big_slow.png"]["is_oversized"] is True
+    # Same pixel count, but fast-copy -> not oversized.
+    assert by_name["big_fast.png"]["is_oversized"] is False
+    assert by_name["small.png"]["is_oversized"] is False
+
+
+def test_get_files_from_preflight_image_without_oversized_defaults_false():
+    preflight = {"image_files": [{"filename": "fig.png", "megapixels": 2.0}]}
+    row = dm.get_files_from_preflight(preflight)[0]
+    assert row["is_oversized"] is False
+
+
 def test_get_files_from_preflight_empty():
     assert dm.get_files_from_preflight({}) == []
 

--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -3,13 +3,13 @@
 The ``display_preflight_tree`` macro used to compute everything about a file
 inline: it looked the badges up in a separate ``file_issues`` dict and decided
 "is this the 00README / a selected top-level file?" with string comparisons
-against extra template parameters. C1 (issue badges) and C3 (file-use status,
-delete defaults) both need to write that same "Auto-detected Notes" cell, so
+against extra template parameters. Issue badges and file-use status,
+delete default, both need to write that same "Auto-detected Notes" cell, so
 without a single seam they conflict in the controller and the template.
 
 This module provides that seam: it folds the per-file issue badges and the
 top-level / README flags into each file object, so the template renders
-fields from one object instead of computing them. C3 can extend the object
+fields from one object instead of computing them. The next phase will extend the object
 (used/unused, delete defaults, image size) without touching Jinja.
 
 Pure transform -- no I/O.
@@ -41,6 +41,11 @@ def build_file_rows(
     ``is_readme`` / ``is_toplevel`` drive both the disabled delete checkbox and
     the usage note; ``badges`` render before the note. The input dicts are not
     mutated.
+
+    Any other keys already on a file note are preserved unchanged -- e.g. the
+    image size fields ``width`` / ``height`` / ``megapixels`` / ``is_oversized``
+    that ``get_files_from_preflight`` attaches for image files (SUBMISSION-172). This is the point of the single per-file object: new per-file data is
+    added upstream and flows through without touching this helper or the macro.
     """
     issues = file_issues or {}
     top_levels = set(selected_top_level_files or [])

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -56,3 +56,16 @@ def test_none_issues_and_none_selection_are_safe():
 
 def test_empty_notes_returns_empty():
     assert build_file_rows([], {}, ["main.tex"]) == []
+
+
+def test_image_size_fields_pass_through_unchanged():
+    """Extra per-file keys (e.g. the image size fields get_files_from_preflight
+    attaches) flow through to the row without special handling -- the point of
+    the single per-file object (SUBMISSION-172)."""
+    notes = [{"filename": "big.png", "width": 7000, "height": 7000,
+              "megapixels": 49.0, "file_bytes": 12_000_000, "is_oversized": True}]
+    row = build_file_rows(notes, {}, [])[0]
+    assert row["megapixels"] == 49.0
+    assert row["width"] == 7000
+    assert row["is_oversized"] is True
+    assert row["file_bytes"] == 12_000_000

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -4,6 +4,11 @@
 {{super()}}
  <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
  <script src="{{ url_for('static', filename='js/review_top_level_guard.js') }}" defer></script>
+ <style>
+   /* Oversized-image row highlight (SUBMISSION-172), mirroring 1.5's
+      cream row tint. !important so it wins over the is-striped zebra shading. */
+   .review-files-table tbody tr.is-oversized td { background-color: #fffbe6 !important; }
+ </style>
 {% endblock addl_head %}
 
 {# Renders one row of the Review Files table for a preflight-detected file,
@@ -22,7 +27,10 @@
    touching this macro. #}
 {% macro display_preflight_tree(key, item) %}
   {% if 'filename' in item %}
-  <tr>
+  {# Oversized-image rows get a cream tint (SUBMISSION-172), mirroring
+     1.5. is_oversized is authoritative from preflight (large AND not
+     pdftex-fast-copy). #}
+  <tr{% if item.is_oversized %} class="is-oversized"{% endif %}>
     <td class="has-text-centered">
       <input type="hidden" name="all_files" value="{{ item.filename }}">
       {% if item.is_readme %}
@@ -37,7 +45,9 @@
         <input type="checkbox" name="selected_files" value="{{ item.filename }}">
       {% endif %}
     </td>
-    <td>{{ item.filename }}</td>
+    {# Image files show their size next to the name, MP to two decimals,
+       mirroring 1.5 (e.g. "figure.png (36.00 MP)"). (SUBMISSION-172) #}
+    <td>{{ item.filename }}{% if item.megapixels %} ({{ '%.2f'|format(item.megapixels) }} MP){% endif %}</td>
     <td>
       {# Preflight issue badges (SUBMISSION-210), severity-colored, before the
          auto-detected usage note. #}


### PR DESCRIPTION
Summary: Add image size and highlighting for oversize images.

Details:

Carry per-image megapixels/is_oversized (plus width/height/file_bytes) from preflight's image_files[] through get_files_from_preflight onto the file row. Mirror 1.5's presentation: show size as "(NN.NN MP)" next to the file name, and tint the row cream when the image is oversized. is_oversized is authoritative from preflight (large AND not pdftex-fast-copy), so fast-copy images are never flagged regardless of size; the flag is not recomputed. Stacked on the SUBMISSION-219 PR.

<img width="612" height="308" alt="OversizeImageHighlighting-Screenshot 2026-08-06 at 12 00 21 PM" src="https://github.com/user-attachments/assets/91e8e964-5089-453f-865d-d5886e638668" />
