### PR TITLE
SUBMISSION-220: show "Not used" for unreferenced files

### DIFF
--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -60,8 +60,8 @@ def build_file_rows(
         row["is_toplevel"] = filename in top_levels
         # Unused = an ordinary file (not the 00README, not a selected top-level)
         # that no TeX/bib file references. These render "Not used", mirroring 1.5
-        # (SUBMISSION-220 / C3.1a). Display only -- this does not (yet) pre-check
-        # the delete box; that's C3.2, gated on the delete-of-used policy.
+        # (SUBMISSION-220). Display only -- this does not (yet) pre-check
+        # the delete box; that comes later, gated on the delete-of-used policy.
         row["is_unused"] = (
             not row["is_readme"]
             and not row["is_toplevel"]

--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -36,11 +36,13 @@ def build_file_rows(
     * ``badges`` -- per-file issue badges ``[{severity, label}, ...]`` (empty
       list when the file has none);
     * ``is_readme`` -- ``True`` for ``00README.json`` (build-directives file);
-    * ``is_toplevel`` -- ``True`` when the file is a selected top-level TeX file.
+    * ``is_toplevel`` -- ``True`` when the file is a selected top-level TeX file;
+    * ``is_unused`` -- ``True`` for an ordinary file that nothing references
+      (rendered as "Not used").
 
     ``is_readme`` / ``is_toplevel`` drive both the disabled delete checkbox and
-    the usage note; ``badges`` render before the note. The input dicts are not
-    mutated.
+    the usage note; ``is_unused`` drives the "Not used" note; ``badges`` render
+    before the note. The input dicts are not mutated.
 
     Any other keys already on a file note are preserved unchanged -- e.g. the
     image size fields ``width`` / ``height`` / ``megapixels`` / ``is_oversized``
@@ -56,5 +58,16 @@ def build_file_rows(
         row["badges"] = issues.get(filename) or []
         row["is_readme"] = filename == README_FILENAME
         row["is_toplevel"] = filename in top_levels
+        # Unused = an ordinary file (not the 00README, not a selected top-level)
+        # that no TeX/bib file references. These render "Not used", mirroring 1.5
+        # (SUBMISSION-220 / C3.1a). Display only -- this does not (yet) pre-check
+        # the delete box; that's C3.2, gated on the delete-of-used policy.
+        row["is_unused"] = (
+            not row["is_readme"]
+            and not row["is_toplevel"]
+            and not (row.get("used_by")
+                     or row.get("used_by_tex")
+                     or row.get("used_by_bib"))
+        )
         rows.append(row)
     return rows

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -44,9 +44,30 @@ def test_input_dicts_are_not_mutated():
     notes = _notes()
     build_file_rows(notes, {"main.tex": [{"severity": "danger", "label": "x"}]},
                     ["main.tex"])
-    # Original notes must be untouched (no badges/is_readme/is_toplevel leaked in).
-    assert all("badges" not in n and "is_readme" not in n
-               and "is_toplevel" not in n for n in notes)
+    # Original notes must be untouched (no derived keys leaked in).
+    assert all(k not in n for n in notes
+               for k in ("badges", "is_readme", "is_toplevel", "is_unused"))
+
+
+def test_is_unused_only_for_unreferenced_ordinary_files():
+    """"Not used" = an ordinary file nothing references. The 00README, the
+    selected top-level, and any referenced file are all 'used'. (SUBMISSION-220
+    / C3.1a)"""
+    notes = [
+        {"filename": "00README.json"},
+        {"filename": "main.tex"},                              # selected top-level
+        {"filename": "refs.bib", "used_by_bib": ["main.tex"]},  # referenced
+        {"filename": "sec.tex", "used_by_tex": ["main.tex"]},   # referenced
+        {"filename": "fig.png", "used_by": ["main.tex"]},       # referenced
+        {"filename": "orphan.png"},                             # nothing references
+    ]
+    by_name = {r["filename"]: r for r in build_file_rows(notes, {}, ["main.tex"])}
+    assert by_name["orphan.png"]["is_unused"] is True
+    assert by_name["00README.json"]["is_unused"] is False
+    assert by_name["main.tex"]["is_unused"] is False
+    assert by_name["refs.bib"]["is_unused"] is False
+    assert by_name["sec.tex"]["is_unused"] is False
+    assert by_name["fig.png"]["is_unused"] is False
 
 
 def test_none_issues_and_none_selection_are_safe():

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -51,8 +51,7 @@ def test_input_dicts_are_not_mutated():
 
 def test_is_unused_only_for_unreferenced_ordinary_files():
     """"Not used" = an ordinary file nothing references. The 00README, the
-    selected top-level, and any referenced file are all 'used'. (SUBMISSION-220
-    / C3.1a)"""
+    selected top-level, and any referenced file are all 'used'. (SUBMISSION-220)"""
     notes = [
         {"filename": "00README.json"},
         {"filename": "main.tex"},                              # selected top-level

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -59,6 +59,10 @@
         Build directives file
       {% elif item.is_toplevel %}
         Used: top-level file
+      {% elif item.is_unused %}
+        {# Nothing references this file (SUBMISSION-220 / C3.1a). Display only:
+           the delete box is not auto-checked yet -- that is C3.2. #}
+        Not used
       {% else %}
         {% if item.used_by %}Used by: {{ item.used_by | join(', ') }}<br>{% endif %}
         {% if item.used_by_tex %}Used by (TeX): {{ item.used_by_tex | join(', ') }}<br>{% endif %}

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -60,8 +60,8 @@
       {% elif item.is_toplevel %}
         Used: top-level file
       {% elif item.is_unused %}
-        {# Nothing references this file (SUBMISSION-220 / C3.1a). Display only:
-           the delete box is not auto-checked yet -- that is C3.2. #}
+        {# Nothing references this file (SUBMISSION-220). Display only:
+           the delete box is not auto-checked yet -- that is coming next. #}
         Not used
       {% else %}
         {% if item.used_by %}Used by: {{ item.used_by | join(', ') }}<br>{% endif %}


### PR DESCRIPTION
Summary: 1.5 parity ticket: add Not Used designation to 2.0 list files on Review Files page. Previous was done by Javascript.

Details:

Compute is_unused in build_file_rows (ordinary file, not the 00README or a selected top-level, with no used_by/used_by_tex/used_by_bib reference) and render "Not used" in the Review Files Notes column, mirroring 1.5. Display only — the delete box is not auto-checked; gated on the delete-of-used policy. Stacked on the SUBMISSION-172 PR.

<img width="569" height="215" alt="AddedBackNotUsedScreenshot 2026-08-07 at 11 42 27 AM" src="https://github.com/user-attachments/assets/aa737178-f551-4397-9d8d-a2538cc57f44" />
