### PR TITLE
SUBMISSION-221: protect used files from deletion; label maybe-used.

### DIFF
--- a/submit_ce/domain/event/process.py
+++ b/submit_ce/domain/event/process.py
@@ -499,6 +499,12 @@ class SetDecisions(EventWithSideEffect):
 
     files_to_delete: list[str]
 
+    # Confidently-used source filenames (preflight resolved-edge set), computed
+    # server-side by the controller. Protected from deletion alongside the
+    # selected top-level file(s) (SUBMISSION-221 / C3.2a). Defaults empty so
+    # existing callers/tests are unaffected.
+    protected_sources: list[str] = field(default_factory=list)
+
     bytes_removed: int = 0
 
     def validate_pre_lock(self, submission: Submission) -> None:
@@ -531,16 +537,17 @@ class SetDecisions(EventWithSideEffect):
         # not bounced back to Upload for a needless re-scan.
         if self.files_to_delete:
             file_store.delete_preflight(submission.submission_id)
-        # Authoritative guard (SUBMISSION-209): never delete a file the user has
-        # selected as a top-level TeX file -- that's what we're about to compile.
-        # Runs under the submission row lock taken by save(), so it can't race a
+        # Authoritative guard: never delete files the submission needs -- the
+        # selected top-level TeX file(s) (SUBMISSION-209) and any confidently-used
+        # file preflight resolved a reference to (SUBMISSION-221 / C3.2a). Runs
+        # under the submission row lock taken by save(), so it can't race a
         # concurrent decisions change.
-        protected = _protected_top_level_sources(self.decisions)
+        protected = _protected_top_level_sources(self.decisions) | set(self.protected_sources)
         for path in self.files_to_delete:
             if path in protected:
                 logger.warning(
-                    "Refusing to delete selected top-level file %s for "
-                    "submission %s", path, submission.submission_id)
+                    "Refusing to delete protected (top-level or used) file %s "
+                    "for submission %s", path, submission.submission_id)
                 continue
             file = file_store.delete_source_file(submission.submission_id, path)
             if file:

--- a/submit_ce/domain/event/tests/test_set_decisions_guard.py
+++ b/submit_ce/domain/event/tests/test_set_decisions_guard.py
@@ -107,6 +107,36 @@ def test_execute_deletes_non_toplevel_and_counts_bytes():
     assert e.bytes_removed == 20
 
 
+def test_execute_skips_confidently_used_files():
+    """protected_sources (the preflight resolved-edge set, computed server-side)
+    are never deleted, mirroring the top-level guard -- even though they aren't
+    top-level. Unprotected files still delete. (SUBMISSION-221 / C3.2a)"""
+    s = _submission()
+    api = _FakeApi()
+    e = SetDecisions(
+        creator=s.creator,
+        decisions={'sources': [{'filename': 'main.tex'}]},
+        files_to_delete=['fig.png', 'refs.bib', 'junk.png'],
+        protected_sources=['fig.png', 'refs.bib'],
+    )
+    e.execute(api, s)
+    assert api._store.deleted == ['junk.png']
+    assert e.bytes_removed == 10
+
+
+def test_execute_protected_sources_default_empty_deletes_normally():
+    """Callers that don't pass protected_sources keep the old behavior."""
+    s = _submission()
+    api = _FakeApi()
+    e = SetDecisions(
+        creator=s.creator,
+        decisions={'sources': [{'filename': 'main.tex'}]},
+        files_to_delete=['fig.png'],
+    )
+    e.execute(api, s)
+    assert api._store.deleted == ['fig.png']
+
+
 def test_protected_top_level_sources_helper():
     """toplevel + usage-less sources are protected; include/ignore are not."""
     decisions = {'sources': [

--- a/submit_ce/implementations/compile/directive_manager.py
+++ b/submit_ce/implementations/compile/directive_manager.py
@@ -53,13 +53,48 @@ class DirectiveManager:
                                  if k in ('compiler',)}
         return result
 
+    def used_source_filenames(preflight_data: dict) -> set:
+        '''Filenames preflight *resolved* a reference to (confidently used).
+
+        The union of every tex file's ``used_other_files`` / ``used_tex_files`` /
+        ``used_bib_files`` -- the resolved-edge set. These are high-confidence
+        "this file is needed" signals (unlike ``maybe_used_files``, a coarse
+        guess). Used by the Review Files delete-guard to refuse deletion of
+        confidently-used files (SUBMISSION-221 / C3.2a).
+        '''
+        used: set = set()
+        for tex_file in (preflight_data or {}).get('tex_files', []):
+            for key in ('used_other_files', 'used_tex_files', 'used_bib_files'):
+                for name in tex_file.get(key, []):
+                    if name:
+                        used.add(name)
+        return used
+
     def get_files_from_preflight(preflight_data: dict) -> list:
         files = {}
-        for section in ('detected_toplevel_files', 'tex_files', 'ancillary_files', 'maybe_used_files', 'image_files'):
+        # Object sections: each entry is a dict carrying a 'filename'.
+        for section in ('detected_toplevel_files', 'tex_files', 'image_files'):
             for f in preflight_data.get(section, []):
                 filename = f.get('filename')
                 if filename and filename not in files:
                     files[filename] = {'filename': filename}
+        # Plain-string sections: PreflightResponse types ancillary_files and
+        # maybe_used_files as list[str], so each entry is a filename string, not
+        # a dict. (These are almost always empty, which is why treating them as
+        # dicts went unnoticed until a .pygtex file populated maybe_used_files.)
+        for section in ('ancillary_files', 'maybe_used_files'):
+            for filename in preflight_data.get(section, []):
+                if filename and filename not in files:
+                    files[filename] = {'filename': filename}
+
+        # Tag maybe-used files (SUBMISSION-221 / C3.2a). These are a low-confidence
+        # guess -- preflight kept them (by extension: only .pygtex) but couldn't
+        # resolve a reference. Tagging lets the UI label them "Possibly used" (not
+        # "Not used") and leave them deletable but unprotected. A resolved edge
+        # below wins over this flag (handled in build_file_rows).
+        for filename in preflight_data.get('maybe_used_files', []):
+            if filename:
+                files[filename]['is_maybe_used'] = True
 
         for tex_file in preflight_data.get('tex_files', []):
             tex_name = tex_file.get('filename')

--- a/submit_ce/implementations/tests/test_directive_manager.py
+++ b/submit_ce/implementations/tests/test_directive_manager.py
@@ -52,11 +52,13 @@ def test_convert_zzrm_to_user_decisions_drops_process_compiler_version():
 
 
 def test_get_files_from_preflight_collects_all_sections():
+    # NB: PreflightResponse types ancillary_files and maybe_used_files as
+    # list[str] -- plain filenames, not dicts (SUBMISSION-221 fix).
     preflight = {
         "detected_toplevel_files": [{"filename": "main.tex"}],
         "tex_files": [{"filename": "main.tex"}, {"filename": "extra.tex"}],
-        "ancillary_files": [{"filename": "anc.dat"}],
-        "maybe_used_files": [{"filename": "maybe.txt"}],
+        "ancillary_files": ["anc.dat"],
+        "maybe_used_files": ["maybe.txt"],
         "image_files": [{"filename": "fig.pdf"}],
     }
     result = dm.get_files_from_preflight(preflight)
@@ -114,6 +116,27 @@ def test_get_files_from_preflight_image_without_oversized_defaults_false():
     preflight = {"image_files": [{"filename": "fig.png", "megapixels": 2.0}]}
     row = dm.get_files_from_preflight(preflight)[0]
     assert row["is_oversized"] is False
+
+
+def test_used_source_filenames_unions_resolved_edges():
+    """The confidently-used set = union of every tex file's resolved edges
+    (SUBMISSION-221 / C3.2a)."""
+    preflight = {"tex_files": [
+        {"filename": "main.tex", "used_other_files": ["fig.png"],
+         "used_bib_files": ["refs.bib"]},
+        {"filename": "sec.tex", "used_tex_files": ["sub.tex"]},
+    ]}
+    assert dm.used_source_filenames(preflight) == {"fig.png", "refs.bib", "sub.tex"}
+    assert dm.used_source_filenames({}) == set()
+
+
+def test_get_files_from_preflight_tags_maybe_used():
+    """Files from the maybe_used_files section are tagged is_maybe_used so the UI
+    can tell them apart from truly-unused files (SUBMISSION-221 / C3.2a)."""
+    preflight = {"maybe_used_files": ["guess.sty"], "tex_files": []}
+    row = dm.get_files_from_preflight(preflight)[0]
+    assert row["filename"] == "guess.sty"
+    assert row["is_maybe_used"] is True
 
 
 def test_get_files_from_preflight_empty():

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -329,20 +329,24 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
     existing_paths = {f.path for f in workspace.files}
     files_to_delete = [p for p in params.getlist('selected_files') if p in existing_paths]
 
-    # Never delete a file the user has selected as a top-level TeX file -- that's
-    # what we're about to compile (SUBMISSION-209). The template disables these
-    # checkboxes, but a crafted or stale POST can still carry them, so we filter
-    # here and warn the user. The authoritative guard is in SetDecisions.execute,
-    # which runs under the submission row lock.
+    # Never delete files the submission needs: the selected top-level TeX
+    # file(s) (SUBMISSION-209) and any file preflight resolved a reference to
+    # (SUBMISSION-221 / C3.2a). maybe-used and unused files stay deletable. The
+    # template disables these checkboxes, but a crafted or stale POST can still
+    # carry them, so we filter here and warn. The authoritative guard is in
+    # SetDecisions.execute, which runs under the submission row lock.
     selected_top_levels = _selected_top_level_files(params)
-    protected = [p for p in files_to_delete if p in selected_top_levels]
+    used_files = dm.used_source_filenames(_get_preflight_data(submission_id) or {})
+    protected_set = set(selected_top_levels) | used_files
+    protected = [p for p in files_to_delete if p in protected_set]
     if protected:
-        files_to_delete = [p for p in files_to_delete if p not in selected_top_levels]
+        files_to_delete = [p for p in files_to_delete if p not in protected_set]
         alerts.flash_warning(
-            "We kept your selected top-level TeX file(s) and did not delete "
-            f"them: {', '.join(protected)}. To delete one, first remove it from "
-            "the Top-Level TeX selection.",
-            title="Top-level file not deleted")
+            "We kept files your submission needs and did not delete them: "
+            f"{', '.join(protected)}. A top-level TeX file can be freed for "
+            "deletion by removing it from the Top-Level TeX selection; a "
+            "referenced file must first be unreferenced in your source.",
+            title="Files not deleted")
 
     # If the POST carries none of the review-form fields, the user clicked
     # "next" without changing anything; don't invalidate preflight.
@@ -366,7 +370,8 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
 
     try:
         cmd = SetDecisions(creator=submitter, client=client,
-                           decisions=new_decisions, files_to_delete=files_to_delete)
+                           decisions=new_decisions, files_to_delete=files_to_delete,
+                           protected_sources=sorted(used_files))
         current_app.api.save(cmd, submission_id=submission_id)
         # Return whether PREFLIGHT was invalidated. Only a change to the file *set*
         # (a deletion) invalidates it, so the caller returns to Upload to re-run the

--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -37,12 +37,17 @@ def build_file_rows(
       list when the file has none);
     * ``is_readme`` -- ``True`` for ``00README.json`` (build-directives file);
     * ``is_toplevel`` -- ``True`` when the file is a selected top-level TeX file;
-    * ``is_unused`` -- ``True`` for an ordinary file that nothing references
-      (rendered as "Not used").
+    * ``is_used`` -- an ordinary file preflight resolved a reference to;
+    * ``is_maybe_used`` -- an ordinary file only in the coarse ``maybe_used_files``
+      guess bucket (rendered "Possibly used");
+    * ``is_unused`` -- an ordinary file nothing references (rendered "Not used");
+    * ``is_protected`` -- must not be deleted here (readme, selected top-level, or
+      confidently-used); drives the disabled delete checkbox.
 
-    ``is_readme`` / ``is_toplevel`` drive both the disabled delete checkbox and
-    the usage note; ``is_unused`` drives the "Not used" note; ``badges`` render
-    before the note. The input dicts are not mutated.
+    ``is_readme`` / ``is_toplevel`` / ``is_used`` / ``is_maybe_used`` / ``is_unused``
+    are mutually exclusive and drive the usage note; ``is_protected`` drives the
+    delete checkbox; ``badges`` render before the note. The input dicts are not
+    mutated.
 
     Any other keys already on a file note are preserved unchanged -- e.g. the
     image size fields ``width`` / ``height`` / ``megapixels`` / ``is_oversized``
@@ -58,16 +63,22 @@ def build_file_rows(
         row["badges"] = issues.get(filename) or []
         row["is_readme"] = filename == README_FILENAME
         row["is_toplevel"] = filename in top_levels
-        # Unused = an ordinary file (not the 00README, not a selected top-level)
-        # that no TeX/bib file references. These render "Not used", mirroring 1.5
-        # (SUBMISSION-220). Display only -- this does not (yet) pre-check
-        # the delete box; that comes later, gated on the delete-of-used policy.
-        row["is_unused"] = (
-            not row["is_readme"]
-            and not row["is_toplevel"]
-            and not (row.get("used_by")
-                     or row.get("used_by_tex")
-                     or row.get("used_by_bib"))
-        )
+        # Usage classification (SUBMISSION-221 / C3.2a), by descending confidence:
+        #   is_used       -- preflight resolved a reference to it (used_by* edges);
+        #   is_maybe_used -- only in the coarse maybe_used_files guess bucket;
+        #   is_unused     -- nothing references it at all ("Not used").
+        # A resolved edge wins over the maybe-used flag. The 00README and a
+        # selected top-level are handled separately and are none of these.
+        raw_maybe_used = bool(row.get("is_maybe_used"))
+        used_refs = bool(row.get("used_by")
+                         or row.get("used_by_tex")
+                         or row.get("used_by_bib"))
+        ordinary = not row["is_readme"] and not row["is_toplevel"]
+        row["is_used"] = ordinary and used_refs
+        row["is_maybe_used"] = ordinary and not used_refs and raw_maybe_used
+        row["is_unused"] = ordinary and not used_refs and not raw_maybe_used
+        # Protected from deletion (C3.2a): the 00README, a selected top-level, or
+        # a confidently-used file. maybe-used and unused files stay deletable.
+        row["is_protected"] = row["is_readme"] or row["is_toplevel"] or row["is_used"]
         rows.append(row)
     return rows

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -46,7 +46,39 @@ def test_input_dicts_are_not_mutated():
                     ["main.tex"])
     # Original notes must be untouched (no derived keys leaked in).
     assert all(k not in n for n in notes
-               for k in ("badges", "is_readme", "is_toplevel", "is_unused"))
+               for k in ("badges", "is_readme", "is_toplevel", "is_used",
+                         "is_unused", "is_protected"))
+
+
+def test_usage_classification_by_confidence():
+    """is_used / is_maybe_used / is_unused are mutually exclusive; a resolved
+    edge beats the maybe-used flag; readme + top-level are none of them but are
+    protected. (SUBMISSION-221 / C3.2a)"""
+    notes = [
+        {"filename": "00README.json"},
+        {"filename": "main.tex"},                                    # top-level
+        {"filename": "fig.png", "used_by": ["main.tex"]},             # used
+        {"filename": "guess.sty", "is_maybe_used": True},             # maybe-used
+        {"filename": "orphan.dat"},                                   # unused
+        {"filename": "both.sty", "used_by_tex": ["main.tex"],         # edge wins
+         "is_maybe_used": True},
+    ]
+    by = {r["filename"]: r for r in build_file_rows(notes, {}, ["main.tex"])}
+
+    assert (by["fig.png"]["is_used"], by["fig.png"]["is_protected"]) == (True, True)
+    assert by["guess.sty"]["is_maybe_used"] is True
+    assert by["guess.sty"]["is_unused"] is False
+    assert by["guess.sty"]["is_protected"] is False          # deletable
+    assert by["orphan.dat"]["is_unused"] is True
+    assert by["orphan.dat"]["is_protected"] is False          # deletable
+    # resolved edge beats the maybe-used flag
+    assert by["both.sty"]["is_used"] is True
+    assert by["both.sty"]["is_maybe_used"] is False
+    # readme + top-level are protected but not used/maybe/unused
+    for f in ("00README.json", "main.tex"):
+        assert by[f]["is_protected"] is True
+        assert not (by[f]["is_used"] or by[f]["is_maybe_used"]
+                    or by[f]["is_unused"])
 
 
 def test_is_unused_only_for_unreferenced_ordinary_files():

--- a/submit_ce/ui/static/js/review_top_level_guard.js
+++ b/submit_ce/ui/static/js/review_top_level_guard.js
@@ -40,8 +40,11 @@
   function syncGuards() {
     var selected = selectedTopLevelFiles();
     deleteCheckboxes().forEach(function (cb) {
-      // Never touch permanently-locked rows (e.g. 00README.json).
-      if (cb.dataset.lock === "permanent") {
+      // Never touch server-locked rows: "permanent" (00README.json) or "used"
+      // (a confidently-used file protected from deletion, SUBMISSION-221 /
+      // C3.2a). Without this, the else-branch below would re-enable used-file
+      // checkboxes that the server rendered disabled.
+      if (cb.dataset.lock) {
         return;
       }
       if (selected.indexOf(cb.value) !== -1) {

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -41,6 +41,13 @@
         <input type="checkbox" name="selected_files" value="{{ item.filename }}"
                disabled
                title="This is a selected top-level TeX file and cannot be deleted here. Remove it from the Top-Level TeX selection first.">
+      {% elif item.is_used %}
+        {# Confidently used (a resolved reference). Protected from deletion here
+           (SUBMISSION-221 / C3.2a); maybe-used files below stay deletable.
+           data-lock keeps the top-level guard JS from re-enabling it on load. #}
+        <input type="checkbox" name="selected_files" value="{{ item.filename }}"
+               disabled data-lock="used"
+               title="This file is used by your submission and cannot be deleted here.">
       {% else %}
         <input type="checkbox" name="selected_files" value="{{ item.filename }}">
       {% endif %}
@@ -59,14 +66,17 @@
         Build directives file
       {% elif item.is_toplevel %}
         Used: top-level file
-      {% elif item.is_unused %}
-        {# Nothing references this file (SUBMISSION-220). Display only:
-           the delete box is not auto-checked yet -- that is coming next. #}
-        Not used
-      {% else %}
+      {% elif item.is_used %}
         {% if item.used_by %}Used by: {{ item.used_by | join(', ') }}<br>{% endif %}
         {% if item.used_by_tex %}Used by (TeX): {{ item.used_by_tex | join(', ') }}<br>{% endif %}
         {% if item.used_by_bib %}Used by (bib): {{ item.used_by_bib | join(', ') }}{% endif %}
+      {% elif item.is_maybe_used %}
+        {# In preflight's coarse maybe_used_files guess -- kept but no resolved
+           reference. Deletable but not suggested (SUBMISSION-221 / C3.2a). #}
+        Possibly used
+      {% else %}
+        {# Nothing references this file (SUBMISSION-220). #}
+        Not used
       {% endif %}
     </td>
   </tr>


### PR DESCRIPTION
Summary:

Implements new use files delete policy: confidently-used
files are protected from deletion, maybe-used files stay deletable but are no
longer mislabeled, truly-unused files are unchanged.

Details:

### Behavior — classify by usage confidence (mutually exclusive)
| Tier | Signal | Delete box | Note |
|------|--------|-----------|------|
| used | preflight resolved a reference (`used_by*`) | disabled | "Used by …" |
| maybe-used | in `maybe_used_files` only (`.pygtex`) | enabled | "Possibly used" |
| unused | nothing references it | enabled | "Not used" |

Top-level and `00README.json` stay protected as before. A resolved edge
outranks the maybe-used flag.

### Guard tiers (both taught about used files)
- **Template**: used-file checkbox `disabled` + `data-lock="used"`.
- **Client JS** (`review_top_level_guard.js`): now skips any `data-lock` row, so
  it no longer re-enables server-disabled used files on load.
- **Controller** (`_update_preflight`): filters used files out of
  `files_to_delete` with a warning flash.
- **Domain** (`SetDecisions.execute`): new `protected_sources` field unioned into
  the existing top-level guard, enforced under the submission row lock.

### Latent bugs fixed (surfaced by this work)
- `get_files_from_preflight` treated `ancillary_files` / `maybe_used_files` as
  dict lists, but `PreflightResponse` types both as `list[str]`. Empty in
  practice until a `.pygtex` file populated `maybe_used_files`, which 500'd the
  Review Files page (`'str' object has no attribute 'get'`). Now read as string
  lists; also fixes the same crash for submissions with `anc/` files.
- `review_top_level_guard.js` re-enabled every non-top-level checkbox on load.

### Divergence from 1.5 (intentional)
1.5 guarded only the top-level file; protecting confidently-used files is a
deliberate safety improvement.

### Tests
- `test_directive_manager.py`: `used_source_filenames`, `is_maybe_used` tagging,
  string-typed section parsing.
- `test_file_context.py`: used / maybe-used / unused / protected classification.
- `test_set_decisions_guard.py`: `execute` refuses `protected_sources`.

Manual QA: `testing/.../tarballs/21_delete_protection_tiers.tar.gz` exercises all
tiers plus the string `maybe_used_files` path.

### Out of scope
Auto-checking unused files for deletion + directory cascade (coming next).

<img width="550" height="392" alt="UsedFilesProtectedScreenshot 2026-08-07 at 4 08 57 PM" src="https://github.com/user-attachments/assets/00e9272c-5f98-4531-a93d-3044a3b536fd" />
