### PR TITLE
SUBMISSION-222: auto-check unused files for deletion

### DIFF
--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -1,5 +1,6 @@
 """Tests for :mod:`submit_ce.ui.controllers.new.review`."""
 
+import re
 from http import HTTPStatus as status
 from unittest.mock import MagicMock
 
@@ -191,6 +192,41 @@ def test_review_files_post_danger_issue_blocks_continue(
     assert b'Cannot continue' in resp.data          # persistent danger card rendered
     assert not any(c.args and isinstance(c.args[0], review.StoreZzrm)
                    for c in mock_save.call_args_list)
+
+
+def test_review_files_get_auto_checks_only_unused(
+        app, authorized_client, sub_files_tex, mocker):
+    """SUBMISSION-222 / C3.2: the delete box is pre-checked for UNUSED files
+    only. Used and selected-top-level files are disabled and unchecked;
+    maybe-used files are enabled but left unchecked (we don't suggest deleting
+    something we merely couldn't resolve)."""
+    preflight = {
+        'detected_toplevel_files': [{'filename': 'main.tex'}],
+        'tex_files': [{'filename': 'main.tex', 'used_other_files': ['used.png']}],
+        'image_files': [{'filename': 'used.png'}, {'filename': 'orphan.png'}],
+        'maybe_used_files': ['guess.pygtex'],
+    }
+    mocker.patch.object(review, '_load_or_create_preflight',
+                        return_value=(preflight, None))
+    url = f"/{sub_files_tex.submission_id}/review_files"
+    resp = authorized_client.get(url)
+    assert resp.status_code == status.OK
+    html = resp.data.decode()
+
+    def box(name):
+        m = re.search(
+            r'<input type="checkbox" name="selected_files" value="%s"[^>]*>'
+            % re.escape(name), html)
+        assert m, f"no delete checkbox rendered for {name}"
+        return m.group(0)
+
+    assert 'checked' in box('orphan.png')                       # unused -> pre-checked
+    assert 'disabled' in box('used.png')                        # used -> protected
+    assert 'checked' not in box('used.png')
+    assert 'disabled' in box('main.tex')                        # top-level -> protected
+    assert 'checked' not in box('main.tex')
+    assert 'disabled' not in box('guess.pygtex')                # maybe-used -> deletable
+    assert 'checked' not in box('guess.pygtex')                 #            -> but not suggested
 
 
 def _make_workspace(*paths):

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -48,6 +48,12 @@
         <input type="checkbox" name="selected_files" value="{{ item.filename }}"
                disabled data-lock="used"
                title="This file is used by your submission and cannot be deleted here.">
+      {% elif item.is_unused %}
+        {# Nothing references this file: pre-checked for deletion, mirroring 1.5
+           (SUBMISSION-222). The submitter can uncheck it, or use "Keep All".
+           maybe-used files (final else) stay deletable but UNchecked -- we don't
+           suggest removing something we merely couldn't resolve. #}
+        <input type="checkbox" name="selected_files" value="{{ item.filename }}" checked>
       {% else %}
         <input type="checkbox" name="selected_files" value="{{ item.filename }}">
       {% endif %}


### PR DESCRIPTION
Summary:

PR to implement auto-checked delete boxes for unused files.

Details:

Pre-check the delete box for is_unused files (nothing references them), mirroring 1.5. Used, top-level and 00README stay disabled; maybe-used files remain enabled but unchecked — we don't suggest deleting something preflight merely couldn't resolve. "Keep All" still clears every box.

With unused files pre-checked, clicking Continue deletes them, which invalidates preflight and routes back to Upload for a re-scan — the intended "delete marked files and continue" flow.

Note: a pre-existing archive-path bug (`./`-prefixed tarball members stored as `.../src/./file`) can make deletion silently no-op; that's tracked separately in SUBMISSION-224 and is not a defect in this change. Stacked on the SUBMISSION-221 PR.

<img width="600" height="665" alt="Screenshot 2026-08-10 at 1 22 29 PM" src="https://github.com/user-attachments/assets/4b0bda44-acd4-41ec-b315-d12e8484f987" />
