### PR TITLE
SUBMISSION-224: normalize archive member paths on extraction (strip ./)

### DIFF
--- a/submit_ce/implementations/file_store/gs_file_store.py
+++ b/submit_ce/implementations/file_store/gs_file_store.py
@@ -172,7 +172,18 @@ class GsFileStore(SubmissionFileStore, FileStoreMixin):
                 for info in zf.infolist():
                     if info.is_dir():
                         continue
-                    store_at = posixpath.join(src_dir, info.filename)
+                    # Normalize the member path before building the object key.
+                    # Archives packed with `tar -C dir .` (and some zips) prefix
+                    # every entry with "./", which would otherwise become a
+                    # literal "./" segment in the GCS key (".../src/./main.tex")
+                    # and never match the normalized filenames preflight reports
+                    # -- silently breaking file deletion. normpath collapses
+                    # "./" and redundant segments; skip the archive root itself.
+                    # (SUBMISSION-224)
+                    rel = posixpath.normpath(info.filename)
+                    if rel in (".", ""):
+                        continue
+                    store_at = posixpath.join(src_dir, rel)
                     self._check_path_safe(submission_id, store_at)
                     with zf.open(info) as file:
                         blob = self.bucket.blob(store_at)
@@ -187,7 +198,12 @@ class GsFileStore(SubmissionFileStore, FileStoreMixin):
                     if extracted is None:
                         continue
                     with extracted as file:
-                        store_at = posixpath.join(src_dir, member.name)
+                        # Strip the "./" prefix that `tar -C dir .` adds; see the
+                        # zip branch above (SUBMISSION-224).
+                        rel = posixpath.normpath(member.name)
+                        if rel in (".", ""):
+                            continue
+                        store_at = posixpath.join(src_dir, rel)
                         self._check_path_safe(submission_id, store_at)
                         blob = self.bucket.blob(store_at)
                         blob.upload_from_file(file, size=member.size)

--- a/submit_ce/implementations/file_store/mock_file_store.py
+++ b/submit_ce/implementations/file_store/mock_file_store.py
@@ -10,6 +10,7 @@ Use it via `mocked_file_store(app)` from `submit_ce/ui/conftest.py`.
 """
 import io
 import json
+import posixpath
 import tarfile
 import zipfile
 from datetime import datetime, timezone
@@ -111,14 +112,22 @@ class MockFileStore(NullFileStore):
                         continue
                     f = tar.extractfile(member)
                     if f is not None:
-                        files[member.name] = f.read()
+                        # Normalize "./"-prefixed member paths to match the GCS
+                        # store (SUBMISSION-224).
+                        rel = posixpath.normpath(member.name)
+                        if rel in (".", ""):
+                            continue
+                        files[rel] = f.read()
         except tarfile.TarError:
             try:
                 with zipfile.ZipFile(io.BytesIO(raw)) as zf:
                     for info in zf.infolist():
                         if info.is_dir():
                             continue
-                        files[info.filename] = zf.read(info)
+                        rel = posixpath.normpath(info.filename)
+                        if rel in (".", ""):
+                            continue
+                        files[rel] = zf.read(info)
             except zipfile.BadZipFile:
                 # Not a recognized archive — store as a single file.
                 files[content.filename] = raw

--- a/submit_ce/implementations/file_store/tests/test_gs_file_store.py
+++ b/submit_ce/implementations/file_store/tests/test_gs_file_store.py
@@ -152,6 +152,28 @@ def test_store_source_package_extracts_members(store, sub_id):
     assert "fig.pdf" in stored_names
 
 
+def test_store_source_package_strips_dotslash_member_paths(store, sub_id):
+    """Archives packed with `tar -C dir .` prefix every member with "./".
+    Those must be stored under a clean, normalized path so preflight filenames
+    match workspace/store paths (otherwise file deletion silently breaks).
+    (SUBMISSION-224)"""
+    tar_stream = make_targz({"./main.tex": b"hello", "./fig/plot.png": b"png"})
+    f = FakeFile("pkg.tar.gz", b"", "application/gzip")
+    f.stream = tar_stream
+    result = store.store_source_package(sub_id, f, chunk_size=4096)
+
+    stored_names = {item["file"] for item in result}
+    assert "main.tex" in stored_names
+    assert "fig/plot.png" in stored_names
+    assert not any(n.startswith("./") for n in stored_names)
+
+    # And they list/retrieve under the clean names.
+    ws = store.get_workspace(sub_id)
+    names = {x.name for x in ws.files}
+    assert "main.tex" in names
+    assert not any(n.startswith("./") for n in names)
+
+
 def test_store_and_get_preview(store, sub_id):
     pdf = b"%PDF-1.4 fake"
     checksum = store.store_preview(sub_id, BytesIO(pdf))


### PR DESCRIPTION
Summarize:

Small PR to normalize archive member paths on extraction.

Details:

Archives packed with `tar -C dir .` prefix every member with `./`, which store_source_package wrote verbatim into the object key (`.../src/./main.tex`). Preflight reports normalized filenames, so Review Files checkboxes never matched workspace paths and file deletion silently no-op'd. Normalize each member via posixpath.normpath in both the zip and tgz extraction branches (mirrored in mock_file_store); skip the archive root. Adds a test that ./-prefixed members store under clean paths. Base develop — independent of the C3 review-UI stack.