### PR TITLE
SUBMISSION-223: Add cascading directory delete checkbox.

### DIFF
--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -229,6 +229,34 @@ def test_review_files_get_auto_checks_only_unused(
     assert 'checked' not in box('guess.pygtex')                 #            -> but not suggested
 
 
+def test_review_files_get_renders_directory_cascade_checkbox(
+        app, authorized_client, sub_files_tex, mocker):
+    """SUBMISSION-223 / C3.2: directory rows carry a JS-only cascade checkbox
+    whose data-dir is the full path prefix (so the cascade JS matches nested
+    file values). The folder control has no `name`, so it is never submitted."""
+    preflight = {
+        'detected_toplevel_files': [{'filename': 'main.tex'}],
+        'tex_files': [{'filename': 'main.tex'}],
+        'image_files': [{'filename': 'fig/plot.png'},
+                        {'filename': 'fig/deep/x.png'}],
+    }
+    mocker.patch.object(review, '_load_or_create_preflight',
+                        return_value=(preflight, None))
+    url = f"/{sub_files_tex.submission_id}/review_files"
+    resp = authorized_client.get(url)
+    assert resp.status_code == status.OK
+    html = resp.data.decode()
+
+    # Nested directory rows get cascade checkboxes with full-path prefixes.
+    assert 'class="dir-delete" data-dir="fig/"' in html
+    assert 'class="dir-delete" data-dir="fig/deep/"' in html
+    # Files render with their full nested paths (what the JS matches against).
+    assert 'name="selected_files" value="fig/plot.png"' in html
+    assert 'name="selected_files" value="fig/deep/x.png"' in html
+    # The folder control is a UI-only toggle: it must not be a submitted field.
+    assert re.search(r'class="dir-delete"[^>]*\bname=', html) is None
+
+
 def _make_workspace(*paths):
     """Build a stand-in workspace whose `.files` carry the given paths."""
     ws = MagicMock()

--- a/submit_ce/ui/static/js/review_delete_cascade.js
+++ b/submit_ce/ui/static/js/review_delete_cascade.js
@@ -1,0 +1,74 @@
+// review_delete_cascade.js  (SUBMISSION-223)
+//
+// Progressive enhancement for the Review Files page. A directory row's Delete
+// checkbox toggles every DELETABLE file checkbox beneath it, and reflects the
+// combined state of those files (checked / unchecked / indeterminate).
+//
+// The folder checkbox has no `name`, so it is never submitted -- only the
+// per-file `selected_files` checkboxes are. With JavaScript off the page still
+// works; the folder box simply does nothing and files are toggled individually.
+//
+// A file "belongs to" a directory when its checkbox value starts with the
+// directory's `data-dir` prefix (values are the preflight-normalized paths, so
+// a nested file matches every ancestor directory's prefix).
+(function () {
+  "use strict";
+
+  function dirCheckboxes() {
+    return document.querySelectorAll('input.dir-delete[data-dir]');
+  }
+
+  function fileCheckboxes() {
+    return document.querySelectorAll('input[name="selected_files"]');
+  }
+
+  // Deletable descendants of a directory: file checkboxes under its prefix that
+  // are not disabled/locked (used, top-level and 00README can't be deleted
+  // here, so they never participate in the cascade or its state).
+  function descendants(dir) {
+    var prefix = dir.dataset.dir;
+    var out = [];
+    fileCheckboxes().forEach(function (cb) {
+      if (!cb.disabled && cb.value.indexOf(prefix) === 0) {
+        out.push(cb);
+      }
+    });
+    return out;
+  }
+
+  // Recompute every folder's checked/indeterminate from its descendants.
+  function syncDirStates() {
+    dirCheckboxes().forEach(function (dir) {
+      var kids = descendants(dir);
+      var checked = kids.filter(function (cb) { return cb.checked; }).length;
+      if (kids.length === 0 || checked === 0) {
+        dir.checked = false;
+        dir.indeterminate = false;
+      } else if (checked === kids.length) {
+        dir.checked = true;
+        dir.indeterminate = false;
+      } else {
+        dir.checked = false;
+        dir.indeterminate = true;
+      }
+    });
+  }
+
+  window.addEventListener("DOMContentLoaded", function () {
+    dirCheckboxes().forEach(function (dir) {
+      dir.addEventListener("change", function () {
+        descendants(dir).forEach(function (cb) { cb.checked = dir.checked; });
+        syncDirStates();
+      });
+    });
+    fileCheckboxes().forEach(function (cb) {
+      cb.addEventListener("change", syncDirStates);
+    });
+    // "Keep All" unchecks boxes directly (no change event); resync afterward.
+    document.querySelectorAll('.keep-all-link').forEach(function (link) {
+      link.addEventListener("click", function () { setTimeout(syncDirStates, 0); });
+    });
+    // Initialise folder states from the server-rendered (auto-checked) files.
+    syncDirStates();
+  });
+})();

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -4,6 +4,7 @@
 {{super()}}
  <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
  <script src="{{ url_for('static', filename='js/review_top_level_guard.js') }}" defer></script>
+ <script src="{{ url_for('static', filename='js/review_delete_cascade.js') }}" defer></script>
  <style>
    /* Oversized-image row highlight (SUBMISSION-172), mirroring 1.5's
       cream row tint. !important so it wins over the is-striped zebra shading. */
@@ -25,7 +26,7 @@
                             candidate.
    C3 will extend this same object (used/unused, delete defaults) without
    touching this macro. #}
-{% macro display_preflight_tree(key, item) %}
+{% macro display_preflight_tree(key, item, prefix='') %}
   {% if 'filename' in item %}
   {# Oversized-image rows get a cream tint (SUBMISSION-172), mirroring
      1.5. is_oversized is authoritative from preflight (large AND not
@@ -87,9 +88,21 @@
     </td>
   </tr>
   {% else %}
-  <tr><td colspan="3"><em>{{ key }}/</em></td></tr>
+  {# Directory row (SUBMISSION-223). The Delete-column checkbox is a JS-only
+     control -- it has no `name`, so it is never submitted; only the per-file
+     `selected_files` checkboxes are. `data-dir` is the full path prefix so the
+     cascade JS can match descendant file checkboxes by value and toggle every
+     deletable file under this directory. Progressive enhancement only: with JS
+     off the folder box does nothing and files stay individually deletable. #}
+  <tr class="dir-row">
+    <td class="has-text-centered">
+      <input type="checkbox" class="dir-delete" data-dir="{{ prefix }}{{ key }}/"
+             aria-label="Select all deletable files in {{ prefix }}{{ key }}/ for deletion">
+    </td>
+    <td colspan="2"><em>{{ key }}/</em></td>
+  </tr>
   {% for k, subitem in item.items() %}
-    {{ display_preflight_tree(k, subitem) }}
+    {{ display_preflight_tree(k, subitem, prefix ~ key ~ '/') }}
   {% endfor %}
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Summary:

Add cascading directory delete checkbox functionality (parity with 1.5). Basically, clicking on a directory delete checkbox propagates action to files in subdirectories. This is dynamically updated and required 
some Javascript on the client side.

Details:

Directory rows get a JS-only Delete checkbox (no `name` → not submitted) that toggles every deletable file beneath them and reflects checked / unchecked / indeterminate state. The `display_preflight_tree` macro threads a path prefix so a folder's `data-dir` matches the nested file paths the cascade keys on; locked files (used / top-level / 00README) are skipped.

Vanilla progressive enhancement (~70 lines, no framework): with JS off, folder boxes do nothing and files stay individually deletable (unused ones still arrive pre-checked from SUBMISSION-222). Adds a render test asserting nested dir rows carry `data-dir` prefixes and the folder control has no `name`.

Stacked on SUBMISSION-222.

<img width="514" height="500" alt="Screenshot 2026-08-11 at 12 27 14 PM" src="https://github.com/user-attachments/assets/f527414a-2151-4261-9156-2b83086b379b" />

<img width="515" height="490" alt="Screenshot 2026-08-11 at 12 27 28 PM" src="https://github.com/user-attachments/assets/714522db-faae-4a6b-9f98-4ff7d92f0387" />



Note: this delivers the cascade *behavior*; matching 1.5's folder icons + indentation + "Directory" notes is tracked separately in upcoming ticket.