### PR TITLE
SUBMISSION-225: Show a friendly error for corrupt or unreadable uploaded archives

### DIFF
--- a/submit_ce/implementations/file_store/gs_file_store.py
+++ b/submit_ce/implementations/file_store/gs_file_store.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import IO, List, Optional
 import json
+import gzip
 import io
 import logging
 import posixpath
@@ -170,53 +171,71 @@ class GsFileStore(SubmissionFileStore, FileStoreMixin):
         is_zip = (content.content_type in ('application/zip', 'application/x-zip-compressed', 'application/x-zip')
                   or (content.filename and content.filename.endswith('.zip')))
 
-        if is_zip:
-            with zipfile.ZipFile(content.stream) as zf:
-                # Validate and normalize every member path up front, so an
-                # archive containing an unsafe entry (absolute path or ".."
-                # traversal) is rejected before we write any blob. normpath
-                # also collapses the "./" prefix that `tar -C dir .` adds, which
-                # would otherwise leave a literal "./" segment in the GCS key
-                # (".../src/./main.tex") that never matches the filenames
-                # preflight reports -- silently breaking file deletion
-                # (SUBMISSION-224). See safe_member_rel (SUBMISSION-230).
-                safe = []
-                for info in zf.infolist():
-                    if info.is_dir():
-                        continue
-                    rel = safe_member_rel(info.filename)
-                    if rel is not None:
-                        safe.append((info, rel))
-                for info, rel in safe:
-                    store_at = posixpath.join(src_dir, rel)
-                    self._check_path_safe(submission_id, store_at)
-                    with zf.open(info) as file:
-                        blob = self.bucket.blob(store_at)
-                        blob.upload_from_file(file, size=info.file_size)
-                        files.append(self._blob_to_file_status(submission_id, blob))
-        elif is_file_tgz(content):
-            with tarfile.open(fileobj=content.stream, mode="r:*") as tar:
-                # Validate/normalize all members first; see the zip branch
-                # above (SUBMISSION-224, SUBMISSION-230).
-                safe = []
-                for member in tar.getmembers():
-                    if not member.isfile():
-                        continue
-                    rel = safe_member_rel(member.name)
-                    if rel is not None:
-                        safe.append((member, rel))
-                for member, rel in safe:
-                    extracted = tar.extractfile(member)
-                    if extracted is None:
-                        continue
-                    with extracted as file:
+        # A corrupt / truncated / mislabeled archive raises BadZipFile / TarError
+        # / gzip errors (at open or mid-iteration). Re-raise as a ValueError with
+        # a user-facing message; the upload controller catches ValueError and
+        # flashes it, so the submitter sees "your archive is unreadable" instead
+        # of a generic "problem uploading" (SUBMISSION-225). The unsafe-path
+        # ValueError raised by safe_member_rel (SUBMISSION-230) is NOT in the
+        # caught tuple, so its specific message still surfaces.
+        try:
+            if is_zip:
+                with zipfile.ZipFile(content.stream) as zf:
+                    # Validate and normalize every member path up front, so an
+                    # archive containing an unsafe entry (absolute path or ".."
+                    # traversal) is rejected before we write any blob. normpath
+                    # also collapses the "./" prefix that `tar -C dir .` adds,
+                    # which would otherwise leave a literal "./" segment in the
+                    # GCS key (".../src/./main.tex") that never matches the
+                    # filenames preflight reports -- silently breaking file
+                    # deletion (SUBMISSION-224). See safe_member_rel
+                    # (SUBMISSION-230).
+                    safe = []
+                    for info in zf.infolist():
+                        if info.is_dir():
+                            continue
+                        rel = safe_member_rel(info.filename)
+                        if rel is not None:
+                            safe.append((info, rel))
+                    for info, rel in safe:
                         store_at = posixpath.join(src_dir, rel)
                         self._check_path_safe(submission_id, store_at)
-                        blob = self.bucket.blob(store_at)
-                        blob.upload_from_file(file, size=member.size)
-                        files.append(self._blob_to_file_status(submission_id, blob))
-        else:
-            raise ValueError(f"Unsupported source package content type: {content.content_type!r}")
+                        with zf.open(info) as file:
+                            blob = self.bucket.blob(store_at)
+                            blob.upload_from_file(file, size=info.file_size)
+                            files.append(self._blob_to_file_status(submission_id, blob))
+            elif is_file_tgz(content):
+                with tarfile.open(fileobj=content.stream, mode="r:*") as tar:
+                    # Validate/normalize all members first; see the zip branch
+                    # above (SUBMISSION-224, SUBMISSION-230).
+                    safe = []
+                    for member in tar.getmembers():
+                        if not member.isfile():
+                            continue
+                        rel = safe_member_rel(member.name)
+                        if rel is not None:
+                            safe.append((member, rel))
+                    for member, rel in safe:
+                        extracted = tar.extractfile(member)
+                        if extracted is None:
+                            continue
+                        with extracted as file:
+                            store_at = posixpath.join(src_dir, rel)
+                            self._check_path_safe(submission_id, store_at)
+                            blob = self.bucket.blob(store_at)
+                            blob.upload_from_file(file, size=member.size)
+                            files.append(self._blob_to_file_status(submission_id, blob))
+            else:
+                raise ValueError(f"Unsupported source package content type: {content.content_type!r}")
+        except (zipfile.BadZipFile, tarfile.TarError,
+                gzip.BadGzipFile, EOFError) as exc:
+            # BadZipFile / TarError.ReadError -> bad magic or non-archive;
+            # gzip.BadGzipFile -> bad CRC; EOFError -> truncated gzip stream.
+            raise ValueError(
+                "We couldn't read your uploaded archive. It may be corrupt or "
+                "incomplete -- please re-create the .tar.gz or .zip and upload "
+                "again."
+            ) from exc
 
         return files
 

--- a/submit_ce/implementations/file_store/tests/test_gs_file_store.py
+++ b/submit_ce/implementations/file_store/tests/test_gs_file_store.py
@@ -182,7 +182,26 @@ def test_store_source_package_rejects_traversal_member(store, sub_id):
     tar_stream = make_targz({"main.tex": b"ok", "../../evil.tex": b"pwn"})
     f = FakeFile("pkg.tar.gz", b"", "application/gzip")
     f.stream = tar_stream
+    with pytest.raises(ValueError):
+        store.store_source_package(sub_id, f, chunk_size=4096)
 
+
+def test_store_source_package_garbage_archive_raises_valueerror(store, sub_id):
+    """Non-archive bytes named .tar.gz surface as a ValueError (which the upload
+    controller turns into a friendly message), not an opaque TarError that would
+    fall through to the generic error handler (SUBMISSION-225)."""
+    f = FakeFile("corrupt.tar.gz", b"\x1f\x8b\x08 not a valid gzip tar stream",
+                 "application/gzip")
+    with pytest.raises(ValueError):
+        store.store_source_package(sub_id, f, chunk_size=4096)
+
+
+def test_store_source_package_truncated_archive_raises_valueerror(store, sub_id):
+    """A *valid* .tar.gz truncated mid-stream raises gzip EOFError, not a
+    TarError -- so the corrupt-archive handling must translate that too
+    (SUBMISSION-225)."""
+    good = make_targz({"main.tex": b"x" * 500}).getvalue()
+    f = FakeFile("truncated.tar.gz", good[: len(good) // 2], "application/gzip")
     with pytest.raises(ValueError):
         store.store_source_package(sub_id, f, chunk_size=4096)
 

--- a/submit_ce/ui/controllers/new/upload.py
+++ b/submit_ce/ui/controllers/new/upload.py
@@ -219,6 +219,17 @@ def upload_files(method: str, params: MultiDict, session: Session,
                                         'our maximum size limit. ' + SUPPORT))
         except HTTPException as ex:
             alerts.flash_failure(Markup(ex.detail))
+        except ValueError as ex:
+            # An unreadable upload the file store rejected -- a corrupt/truncated
+            # archive, or an unsupported content type. Surface a specific message
+            # instead of the generic catch-all below (save() re-raises the store's
+            # ValueError unchanged). (corrupt-archive handling)
+            logger.warning('Unreadable upload for %s: %s',
+                           submission.submission_id, ex)
+            alerts.flash_failure(Markup(
+                'We could not read your uploaded file. It may be corrupt, '
+                'incomplete, or not a supported archive format. Please check the '
+                'file and try uploading it again. ' + SUPPORT))
         except Exception:
             logger.exception('Problem POSTing upload')
             alerts.flash_failure(Markup('There was a problem uploading your file. ' + SUPPORT))


### PR DESCRIPTION
Small PR that replaces the raw gunzip/tar output a corrupt upload used to surface (which also leaked internal `src/...` paths) with a single, user-facing message; the submitter stays on the Upload page with no partial state.

**Change**
- `gs_file_store.store_source_package`: wrap the zip/tgz extraction and translate archive-read failures into a `ValueError` with a friendly message. Caught set: `zipfile.BadZipFile`, `tarfile.TarError` (bad magic / non-archive), `gzip.BadGzipFile` (bad CRC), and **`EOFError`** (truncated gzip). The last is the easy-to-miss case — a *valid* `.tar.gz` truncated mid-stream raises `EOFError`, not `TarError`. The existing unsupported-content-type `ValueError` is unchanged.
- `upload.py`: add an `except ValueError` (before the generic handler) that flashes the specific message. This works because `save()` re-raises the store's exception unchanged — noted so a future change to `save()`'s error handling doesn't silently revert this to the generic message.

**Tests**: garbage-bytes (`ReadError`) and truncated-gzip (`EOFError`) both assert `ValueError` from `store_source_package`.

**No behavior change** for valid uploads. Manual QA: `testing/preflight_error_submissions/tarballs/24_corrupt_archive.tar.gz`.

<img width="1139" height="729" alt="UploadFiles2 0-CorruptedArchiveScreenshot 2026-08-11 at 2 30 30 PM" src="https://github.com/user-attachments/assets/8a51f2a9-4229-4559-869d-67b506b8f7b4" />

