### PR TITLE
SUBMISSION-170: Files: controller/domain support for multiple ordered top-level TeX files 

### DIFF
--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -251,7 +251,14 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     state. Returns a ``stay_on_this_stage`` flow-control result.
     """
     _populate_form(form, preflight_data, user_decisions_data)
-    selected_top_level_files = [f for f in [form.source_file.data] if f]
+    # Reflect ALL persisted top-levels, in order (SUBMISSION-170 / C2.2), so every
+    # selected top-level is protected/rendered -- not just the one in the single
+    # dropdown. Falls back to the form's single selection on a fresh page (no
+    # user_decisions yet).
+    selected_top_level_files = (
+        _ordered_top_level_filenames(user_decisions_data)
+        or [f for f in [form.source_file.data] if f]
+    )
     rdata['selected_top_level_files'] = selected_top_level_files
     # Surface preflight issues (SUBMISSION-210): reason-code-grouped banners
     # + per-file badges, extracted server-side. Issue banners lead; the
@@ -309,6 +316,22 @@ def _get_user_decisions_data(submission_id: str) -> Optional[dict]:
         return None
     return json.loads(blob.download_as_text())
 
+def _ordered_top_level_filenames(user_decisions_data: Optional[dict]) -> list[str]:
+    """Ordered, de-duped top-level filenames from persisted user_decisions.
+
+    Reads the ``sources`` list (the ordered set written by ``_update_preflight``)
+    so multiple selected top-levels round-trip in order on reload
+    (SUBMISSION-170 / C2.2). Returns ``[]`` when there are none.
+    """
+    sources = (user_decisions_data or {}).get('sources') or []
+    out: list[str] = []
+    for src in sources:
+        filename = src.get('filename')
+        if filename and filename not in out:
+            out.append(filename)
+    return out
+
+
 def _selected_top_level_files(params: MultiDict) -> list[str]:
     """Return the top-level TeX file(s) the user has selected, in order.
 
@@ -355,8 +378,14 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
     if not form_fields_present and not files_to_delete:
         return False
 
+    # Persist ALL selected top-level TeX files, in submission order, so multiple
+    # ordered top-levels round-trip (SUBMISSION-170 / C2.2). `selected_top_levels`
+    # comes from `_selected_top_level_files` (source_file + top_level_tex_files[]).
+    # For today's single-dropdown UI this is a one-item list -- identical to the
+    # previous single-source behavior -- so it's a no-op until the multi-select UI
+    # lands (SUBMISSION-226 / C2.3).
     new_decisions = {
-        'sources': [{'filename': params.get('source_file', '')}],
+        'sources': [{'filename': f} for f in selected_top_levels],
         'texlive_version': params.get('compiler_version', ''),
         'process': {
             'compiler': params.get('compiler', ''),

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -198,7 +198,7 @@ def review_files(method: str, params: MultiDict, session: Session,
         # _update_preflight persists the submitted decisions and returns True only
         # when preflight was invalidated (a file was deleted). A selection-only
         # change (compiler / top-level) keeps preflight valid, so we fall through
-        # and advance rather than bouncing to Upload for a needless re-scan. (G29)
+        # and advance rather than bouncing to Upload for a needless re-scan.
         preflight_invalidated = _update_preflight(params, submission_id, workspace, submitter, client)
 
         if preflight_invalidated:
@@ -213,7 +213,7 @@ def review_files(method: str, params: MultiDict, session: Session,
                     title="Cannot generate directives")
                 return stay_on_this_stage((rdata, status.OK, {}))
 
-            # C1.4 (SUBMISSION-216): a danger-severity preflight issue blocks
+            # SUBMISSION-216: a danger-severity preflight issue blocks
             # Continue -- mirrors 1.5's hasPreflightBlockers. Re-render Review
             # Files with the issue banners instead of advancing.
             if has_blocking_issues(preflight_data):
@@ -245,13 +245,13 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
                         user_decisions_data):
     """Populate ``rdata`` for the Review Files template and stay on the stage.
 
-    Shared by the GET path and the C1.4 danger-gate on POST so both render the
+    Shared by the GET path and the danger-gate on POST so both render the
     same page (file table, per-file badges, severity-grouped issue banners).
     Also sets ``has_blocking_issues`` so the template can reflect the blocked
     state. Returns a ``stay_on_this_stage`` flow-control result.
     """
     _populate_form(form, preflight_data, user_decisions_data)
-    # Reflect ALL persisted top-levels, in order (SUBMISSION-170 / C2.2), so every
+    # Reflect ALL persisted top-levels, in order (SUBMISSION-170), so every
     # selected top-level is protected/rendered -- not just the one in the single
     # dropdown. Falls back to the form's single selection on a fresh page (no
     # user_decisions yet).
@@ -265,10 +265,10 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     # backend-status cards follow.
     issue_notifications, file_issues = build_issue_context(preflight_data)
     rdata['file_issues'] = file_issues
-    # F0 (SUBMISSION-219): fold the per-file badges and the top-level / README
+    # SUBMISSION-219: fold the per-file badges and the top-level / README
     # flags into each file row so the template renders fields from one object
     # instead of computing them inline (and re-deriving them from separate
-    # file_issues / selected_top_level_files parameters). Gives C3 a single
+    # file_issues / selected_top_level_files parameters). Gives a single
     # per-file object to extend with used/unused + delete defaults later.
     rdata['file_notes'] = build_file_rows(
         dm.get_files_from_preflight(preflight_data),
@@ -277,11 +277,11 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     )
     rdata['has_blocking_issues'] = any(
         n.get('severity') == 'danger' for n in issue_notifications)
-    # C1.6 (SUBMISSION-218): collapse the per-code issue banners into one card
+    # SUBMISSION-218: collapse the per-code issue banners into one card
     # per severity (danger / warning / info) so the page isn't a long stack.
     cards = group_notifications_by_severity(issue_notifications)
     if rdata['has_blocking_issues']:
-        # C1.4: a persistent danger summary card explaining the block leads the
+        # A persistent danger summary card explaining the block leads the
         # list (rendered on GET too, since the button stays enabled).
         cards = [{
             'title': 'Cannot continue',
@@ -289,7 +289,7 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
             'body': 'Please resolve the highlighted problem(s) before you can continue.',
         }] + cards
     rdata['immediate_notifications'] = cards
-    # C1.5/G6: the passive "preflight complete" / "directives" status cards are
+    # The passive "preflight complete" / "directives" status cards are
     # dropped entirely (per UI-design review) -- the main column is reserved for
     # issues that need the submitter's attention, and nothing replaces them in
     # the sidebar.
@@ -321,7 +321,7 @@ def _ordered_top_level_filenames(user_decisions_data: Optional[dict]) -> list[st
 
     Reads the ``sources`` list (the ordered set written by ``_update_preflight``)
     so multiple selected top-levels round-trip in order on reload
-    (SUBMISSION-170 / C2.2). Returns ``[]`` when there are none.
+    (SUBMISSION-170). Returns ``[]`` when there are none.
     """
     sources = (user_decisions_data or {}).get('sources') or []
     out: list[str] = []
@@ -337,7 +337,7 @@ def _selected_top_level_files(params: MultiDict) -> list[str]:
 
     Supports the current single ``source_file`` field and a future multi-select
     (``top_level_tex_files[]``), so the delete guard already handles one or more
-    selected top-level files (SUBMISSION-209 / C2).
+    selected top-level files (SUBMISSION-209).
     """
     values = list(params.getlist('source_file')) + \
         list(params.getlist('top_level_tex_files[]'))
@@ -354,7 +354,7 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
 
     # Never delete files the submission needs: the selected top-level TeX
     # file(s) (SUBMISSION-209) and any file preflight resolved a reference to
-    # (SUBMISSION-221 / C3.2a). maybe-used and unused files stay deletable. The
+    # (SUBMISSION-221). maybe-used and unused files stay deletable. The
     # template disables these checkboxes, but a crafted or stale POST can still
     # carry them, so we filter here and warn. The authoritative guard is in
     # SetDecisions.execute, which runs under the submission row lock.
@@ -379,11 +379,11 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
         return False
 
     # Persist ALL selected top-level TeX files, in submission order, so multiple
-    # ordered top-levels round-trip (SUBMISSION-170 / C2.2). `selected_top_levels`
+    # ordered top-levels round-trip (SUBMISSION-170). `selected_top_levels`
     # comes from `_selected_top_level_files` (source_file + top_level_tex_files[]).
     # For today's single-dropdown UI this is a one-item list -- identical to the
     # previous single-source behavior -- so it's a no-op until the multi-select UI
-    # lands (SUBMISSION-226 / C2.3).
+    # lands (SUBMISSION-226).
     new_decisions = {
         'sources': [{'filename': f} for f in selected_top_levels],
         'texlive_version': params.get('compiler_version', ''),
@@ -406,7 +406,7 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
         # (a deletion) invalidates it, so the caller returns to Upload to re-run the
         # scan. A selection-only change (compiler / top-level) keeps preflight valid
         # -- SetDecisions regenerated directives but left the report -- so the caller
-        # can advance without a re-scan. (G29 / SUBMISSION-215)
+        # can advance without a re-scan. (SUBMISSION-215)
         return bool(files_to_delete)
     except InvalidEvent:
         # TODO Somehow inform the user

--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -312,6 +312,77 @@ def test_update_preflight_files_to_delete_triggers_save(
     assert mock_save.call_args[1] == {'submission_id': 'sub1'}
 
 
+def test_ordered_top_level_filenames_reads_sources_in_order():
+    """SUBMISSION-170/C2.2: ordered, de-duped filenames from persisted sources."""
+    ud = {'sources': [{'filename': 'b.tex'}, {'filename': 'a.tex'},
+                      {'filename': 'b.tex'}]}
+    assert review._ordered_top_level_filenames(ud) == ['b.tex', 'a.tex']
+    assert review._ordered_top_level_filenames(None) == []
+    assert review._ordered_top_level_filenames({}) == []
+    assert review._ordered_top_level_filenames({'sources': []}) == []
+
+
+def test_update_preflight_persists_ordered_multiple_top_levels(
+        app, authorized_user, mocker):
+    """SUBMISSION-170/C2.2: all selected top-levels persist as an ordered
+    `sources` list (via top_level_tex_files[]), not just `source_file`."""
+    mocker.patch.object(review, '_get_user_decisions_data', return_value=None)
+    with app.app_context():
+        mock_save = mocker.patch.object(app.api, 'save')
+        params = MultiDict([
+            ('top_level_tex_files[]', 'a.tex'),
+            ('top_level_tex_files[]', 'b.tex'),
+            ('compiler', 'pdflatex'),
+            ('compiler_version', '2025'),
+        ])
+        review._update_preflight(
+            params, 'sub1', _make_workspace('a.tex', 'b.tex'),
+            authorized_user, None,
+        )
+    mock_save.assert_called_once()
+    cmd = mock_save.call_args[0][0]
+    assert cmd.decisions['sources'] == [{'filename': 'a.tex'}, {'filename': 'b.tex'}]
+
+
+def test_update_preflight_preserves_top_level_order(app, authorized_user, mocker):
+    """Reordering the selection persists the new order (B before A)."""
+    mocker.patch.object(review, '_get_user_decisions_data', return_value=None)
+    with app.app_context():
+        mock_save = mocker.patch.object(app.api, 'save')
+        params = MultiDict([
+            ('top_level_tex_files[]', 'b.tex'),
+            ('top_level_tex_files[]', 'a.tex'),
+            ('compiler', 'pdflatex'),
+            ('compiler_version', '2025'),
+        ])
+        review._update_preflight(
+            params, 'sub1', _make_workspace('a.tex', 'b.tex'),
+            authorized_user, None,
+        )
+    cmd = mock_save.call_args[0][0]
+    assert cmd.decisions['sources'] == [{'filename': 'b.tex'}, {'filename': 'a.tex'}]
+
+
+def test_update_preflight_single_source_file_unchanged_shape(
+        app, authorized_user, mocker):
+    """Single-dropdown UI (source_file only) still persists a one-item sources
+    list -- C2.2 is a no-op for the current UI."""
+    mocker.patch.object(review, '_get_user_decisions_data', return_value=None)
+    with app.app_context():
+        mock_save = mocker.patch.object(app.api, 'save')
+        params = MultiDict([
+            ('source_file', 'main.tex'),
+            ('compiler', 'pdflatex'),
+            ('compiler_version', '2025'),
+        ])
+        review._update_preflight(
+            params, 'sub1', _make_workspace('main.tex'),
+            authorized_user, None,
+        )
+    cmd = mock_save.call_args[0][0]
+    assert cmd.decisions['sources'] == [{'filename': 'main.tex'}]
+
+
 def test_update_preflight_decisions_unchanged_returns_false(
         app, authorized_user, mocker):
     """Form fields identical to stored user_decisions: no-op, no save."""

--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -163,7 +163,7 @@ def test_review_files_post_no_changes_stores_zzrm_and_advances(
 
 def test_review_files_post_danger_issue_blocks_continue(
         app, authorized_client, sub_files_tex, mocker):
-    """C1.4/SUBMISSION-216: a danger-severity preflight issue blocks Continue --
+    """SUBMISSION-216: a danger-severity preflight issue blocks Continue --
     the controller stays on the stage (200, not a 303 redirect), renders the
     'Cannot continue' card, and does not generate directives or store the
     00README."""
@@ -196,7 +196,7 @@ def test_review_files_post_danger_issue_blocks_continue(
 
 def test_review_files_get_auto_checks_only_unused(
         app, authorized_client, sub_files_tex, mocker):
-    """SUBMISSION-222 / C3.2: the delete box is pre-checked for UNUSED files
+    """SUBMISSION-222: the delete box is pre-checked for UNUSED files
     only. Used and selected-top-level files are disabled and unchecked;
     maybe-used files are enabled but left unchecked (we don't suggest deleting
     something we merely couldn't resolve)."""
@@ -313,7 +313,7 @@ def test_update_preflight_files_to_delete_triggers_save(
 
 
 def test_ordered_top_level_filenames_reads_sources_in_order():
-    """SUBMISSION-170/C2.2: ordered, de-duped filenames from persisted sources."""
+    """SUBMISSION-170: ordered, de-duped filenames from persisted sources."""
     ud = {'sources': [{'filename': 'b.tex'}, {'filename': 'a.tex'},
                       {'filename': 'b.tex'}]}
     assert review._ordered_top_level_filenames(ud) == ['b.tex', 'a.tex']
@@ -324,7 +324,7 @@ def test_ordered_top_level_filenames_reads_sources_in_order():
 
 def test_update_preflight_persists_ordered_multiple_top_levels(
         app, authorized_user, mocker):
-    """SUBMISSION-170/C2.2: all selected top-levels persist as an ordered
+    """SUBMISSION-170: all selected top-levels persist as an ordered
     `sources` list (via top_level_tex_files[]), not just `source_file`."""
     mocker.patch.object(review, '_get_user_decisions_data', return_value=None)
     with app.app_context():
@@ -366,7 +366,7 @@ def test_update_preflight_preserves_top_level_order(app, authorized_user, mocker
 def test_update_preflight_single_source_file_unchanged_shape(
         app, authorized_user, mocker):
     """Single-dropdown UI (source_file only) still persists a one-item sources
-    list -- C2.2 is a no-op for the current UI."""
+    list -- is a no-op for the current UI."""
     mocker.patch.object(review, '_get_user_decisions_data', return_value=None)
     with app.app_context():
         mock_save = mocker.patch.object(app.api, 'save')


### PR DESCRIPTION
Controller/domain half of multiple ordered top-level TeX files work. UI portion is a separate ticket (SUBMISSION-226).

**Change**
- `_update_preflight` now builds `user_decisions.sources` from the full ordered top-level selection — `_selected_top_level_files(params)` (which reads both `source_file` and `top_level_tex_files[]`) — instead of `source_file` alone.
- New `_ordered_top_level_filenames()` reads the ordered `sources` back; `_render_review_page` uses it so **all** selected top-levels are protected/reflected on reload, not just the single dropdown value.

**No behavior change under today's single-dropdown UI**: one selection yields a one-item `sources` list, identical to the previous shape. This is a safe base the multi-select UI (226) builds on. The domain/ZZRM and `SetDecisions` already preserve order; the compile-service caps are a separate enablement ticket.

**Tests**: ordered persist `[a,b]`, reorder `[b,a]`, single-source unchanged shape, and the read-back helper (order + dedupe + empty).

Note: `test_review.py` is also touched by the in-review SUBMISSION-223, so expect a trivial rebase in that file when one of the two merges.
