### PR TITLE
SUBMISSION-226: Review Files: multi-select UI for top-level TeX files.

### DIFF
--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -159,6 +159,7 @@ def review_files(method: str, params: MultiDict, session: Session,
         'preflight_files': {},
         'file_notes': {},
         'selected_top_level_files': [],
+        'top_level_candidates': [],
         'file_issues': {},
     }
 
@@ -260,6 +261,10 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
         or [f for f in [form.source_file.data] if f]
     )
     rdata['selected_top_level_files'] = selected_top_level_files
+    # Candidate top-level TeX files for the multi-select UI (SUBMISSION-226).
+    # `_populate_form` set `source_file.choices` to the detected tex files;
+    # the template builds each `top_level_tex_files[]` dropdown from this list.
+    rdata['top_level_candidates'] = [c[0] for c in form.source_file.choices]
     # Surface preflight issues (SUBMISSION-210): reason-code-grouped banners
     # + per-file badges, extracted server-side. Issue banners lead; the
     # backend-status cards follow.

--- a/submit_ce/ui/controllers/new/tests/test_review.py
+++ b/submit_ce/ui/controllers/new/tests/test_review.py
@@ -257,6 +257,33 @@ def test_review_files_get_renders_directory_cascade_checkbox(
     assert re.search(r'class="dir-delete"[^>]*\bname=', html) is None
 
 
+def test_review_files_get_renders_multiple_top_level_selectors(
+        app, authorized_client, sub_files_tex, mocker):
+    """SUBMISSION-226: persisted multiple top-levels render as ordered
+    `top_level_tex_files[]` dropdowns, each preselected, built from the candidate
+    tex-file list; the field exposes the candidate count for the add cap."""
+    preflight = {
+        'detected_toplevel_files': [{'filename': 'a.tex'}],
+        'tex_files': [{'filename': 'a.tex'}, {'filename': 'b.tex'},
+                      {'filename': 'c.tex'}],
+    }
+    decisions = {'sources': [{'filename': 'b.tex'}, {'filename': 'a.tex'}]}
+    mocker.patch.object(review, '_load_or_create_preflight',
+                        return_value=(preflight, decisions))
+    url = f"/{sub_files_tex.submission_id}/review_files"
+    resp = authorized_client.get(url)
+    assert resp.status_code == status.OK
+    html = resp.data.decode()
+
+    selects = re.findall(
+        r'<select name="top_level_tex_files\[\]"[^>]*>(.*?)</select>', html, re.S)
+    assert len(selects) == 2                                   # one per top-level
+    assert re.search(r'<option value="b.tex" selected>', selects[0])   # order kept
+    assert re.search(r'<option value="a.tex" selected>', selects[1])
+    assert 'data-candidate-count="3"' in html                 # a/b/c candidates
+    assert 'id="tl-add"' in html
+
+
 def _make_workspace(*paths):
     """Build a stand-in workspace whose `.files` carry the given paths."""
     ws = MagicMock()

--- a/submit_ce/ui/static/js/review_top_level_select.js
+++ b/submit_ce/ui/static/js/review_top_level_select.js
@@ -1,0 +1,105 @@
+// review_top_level_select.js  (SUBMISSION-226)
+//
+// Progressive enhancement for the Review Files "Top-level TeX file(s)" widget.
+// The server renders one or more <select name="top_level_tex_files[]"> rows
+// (at least one, so a single top-level is always selectable without JS). This
+// script adds the add / remove / move-up / move-down controls, keeps the
+// selects de-duplicated (a file can be top-level only once), caps the number of
+// rows at the number of candidate TeX files, and -- after any change -- nudges
+// review_top_level_guard.js so the delete checkboxes re-sync to the current
+// top-level set. With JS off, the rendered row(s) still submit.
+(function () {
+  "use strict";
+
+  function field() { return document.getElementById("top-level-tex"); }
+  function rowsContainer() { return document.getElementById("top-level-rows"); }
+  function addButton() { return document.getElementById("tl-add"); }
+
+  function rows() {
+    return Array.prototype.slice.call(
+      document.querySelectorAll("#top-level-rows .top-level-row"));
+  }
+  function selects() {
+    return Array.prototype.slice.call(
+      document.querySelectorAll("#top-level-rows select.top-level-select"));
+  }
+  function candidateCap() {
+    var f = field();
+    return f ? parseInt(f.dataset.candidateCount || "0", 10) : 0;
+  }
+
+  // Disable, in each select, the options chosen in OTHER selects.
+  function dedupe() {
+    var chosen = selects().map(function (s) { return s.value; });
+    selects().forEach(function (s) {
+      Array.prototype.forEach.call(s.options, function (opt) {
+        opt.disabled = (opt.value !== s.value && chosen.indexOf(opt.value) !== -1);
+      });
+    });
+  }
+
+  // Tell the top-level guard the selection changed so it re-syncs delete boxes.
+  function notifyGuard() {
+    var s = selects()[0];
+    if (s) { s.dispatchEvent(new Event("change", { bubbles: true })); }
+  }
+
+  function refresh() {
+    var rs = rows();
+    rs.forEach(function (r, i) {
+      var rm = r.querySelector(".tl-remove");
+      var up = r.querySelector(".tl-move-up");
+      var down = r.querySelector(".tl-move-down");
+      if (rm) { rm.disabled = rs.length <= 1; }        // keep at least one
+      if (up) { up.disabled = (i === 0); }
+      if (down) { down.disabled = (i === rs.length - 1); }
+    });
+    var add = addButton();
+    if (add) { add.disabled = rs.length >= candidateCap(); }
+    dedupe();
+    notifyGuard();
+  }
+
+  function wire(row) {
+    var rm = row.querySelector(".tl-remove");
+    if (rm) rm.addEventListener("click", function () {
+      if (rows().length > 1) { row.remove(); refresh(); }
+    });
+    var up = row.querySelector(".tl-move-up");
+    if (up) up.addEventListener("click", function () {
+      var prev = row.previousElementSibling;
+      if (prev) { rowsContainer().insertBefore(row, prev); refresh(); }
+    });
+    var down = row.querySelector(".tl-move-down");
+    if (down) down.addEventListener("click", function () {
+      var next = row.nextElementSibling;
+      if (next) { rowsContainer().insertBefore(next, row); refresh(); }
+    });
+    var sel = row.querySelector("select.top-level-select");
+    if (sel) sel.addEventListener("change", refresh);
+  }
+
+  function addRow() {
+    var rs = rows();
+    if (!rs.length || rs.length >= candidateCap()) { return; }
+    var clone = rs[rs.length - 1].cloneNode(true);
+    var sel = clone.querySelector("select.top-level-select");
+    // Default the new row to the first candidate not already chosen.
+    var chosen = selects().map(function (s) { return s.value; });
+    Array.prototype.some.call(sel.options, function (opt) {
+      if (chosen.indexOf(opt.value) === -1) { sel.value = opt.value; return true; }
+      return false;
+    });
+    rowsContainer().appendChild(clone);
+    wire(clone);
+    refresh();
+  }
+
+  window.addEventListener("DOMContentLoaded", function () {
+    if (!rowsContainer()) { return; }
+    rows().forEach(wire);
+    var add = addButton();
+    if (add) { add.addEventListener("click", addRow); }
+    refresh();
+  });
+})();

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -4,6 +4,7 @@
 {{super()}}
  <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
  <script src="{{ url_for('static', filename='js/review_top_level_guard.js') }}" defer></script>
+ <script src="{{ url_for('static', filename='js/review_top_level_select.js') }}" defer></script>
  <script src="{{ url_for('static', filename='js/review_delete_cascade.js') }}" defer></script>
  <style>
    /* Oversized-image row highlight (SUBMISSION-172), mirroring 1.5's
@@ -241,20 +242,43 @@
     {% endfor %}
   </div>
 
-  {# Top-level TeX file. Submit 2.0 supports a single top-level file
-     (unlike legacy 1.5 which allowed multiple with reordering). #}
-  <div class="field">
-    <label class="label" for="source_file">Top-level TeX file</label>
-    <p class="help">Our automated scan tries to identify the top-level
-      TeX file. You can change it here or keep the auto-selection.</p>
-    <div class="control">
-      <div class="select is-fullwidth">
-        {{ form.source_file }}
+  {# Top-level TeX file(s) (SUBMISSION-226). One or more may be selected;
+     multiple compile concatenated in the order shown (top -> bottom). Each row
+     submits as `top_level_tex_files[]`, which the controller reads as an ordered
+     list (SUBMISSION-170). The add / remove / move buttons are progressive
+     enhancement wired by review_top_level_select.js; with JS off, the row(s)
+     rendered here still submit, so a single top-level is always selectable. #}
+  <div class="field" id="top-level-tex"
+       data-candidate-count="{{ top_level_candidates | length }}">
+    <label class="label">Top-level TeX file(s)</label>
+    <p class="help">Our automated scan pre-selects the top-level TeX file(s).
+      You can change, add, remove, or reorder them; multiple files are compiled
+      in the order listed.</p>
+    <div id="top-level-rows">
+      {% for sel in (selected_top_level_files or ['']) %}
+      <div class="field has-addons top-level-row">
+        <div class="control is-expanded">
+          <div class="select is-fullwidth">
+            <select name="top_level_tex_files[]" class="top-level-select">
+              {% for cand in top_level_candidates %}
+              <option value="{{ cand }}"{% if cand == sel %} selected{% endif %}>{{ cand }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <div class="control">
+          <button type="button" class="button tl-move-up" title="Move up" aria-label="Move up">&uarr;</button>
+        </div>
+        <div class="control">
+          <button type="button" class="button tl-move-down" title="Move down" aria-label="Move down">&darr;</button>
+        </div>
+        <div class="control">
+          <button type="button" class="button tl-remove" title="Remove this top-level file" aria-label="Remove">&times;</button>
+        </div>
       </div>
+      {% endfor %}
     </div>
-    {% for error in form.source_file.errors %}
-      <p class="help is-danger">{{ error }}</p>
-    {% endfor %}
+    <button type="button" id="tl-add" class="button is-small">+ Add top-level file</button>
   </div>
 
   {# Review Files list. Files checked for deletion will be removed when


### PR DESCRIPTION
UI half of multiple ordered top-level TeX files. Stacked on SUBMISSION-170 (controller/domain ordered `sources` wiring); Config setting concern (max TeX files = 1) is resolved with no code (the deployed compile service already concatenates ≥2 top-levels from the 00README `sources` list — confirmed end-to-end in 2.0).

**Change**
- Replaced the single top-level dropdown with a multi-row widget: one `<select name="top_level_tex_files[]">` per selected top-level (≥1), each preselected in order, with move up / move down / remove buttons and an "Add top-level file" button. Multiple files compile concatenated in the order shown.
- New `review_top_level_select.js` (vanilla, progressive enhancement): add (picks first unchosen, capped at the number of candidate TeX files), remove (keeps ≥1), reorder, de-dupe options across rows, and nudges `review_top_level_guard.js` so the delete checkboxes re-sync to the current top-level set.
- `review.py` exposes `top_level_candidates`; base `rdata` gets a safe default.

**Graceful degradation:** with JS off, the server-rendered row(s) still submit `top_level_tex_files[]`, so a single top-level is always selectable.

**Composition:** builds on 170's ordered persistence and coexists with 223's directory-cascade (different regions of the template).

**Tests:** render test asserts persisted multiple top-levels render as ordered, preselected `top_level_tex_files[]` dropdowns with the candidate count for the add cap.

**Verified end-to-end:** a two-top-level submission compiled to one concatenated PDF (main1 → main2) in 2.0's Process step.

<img width="1134" height="1073" alt="ReviewFiles-2 0-MultiTopLevelTeXfiles-Screenshot 2026-08-11 at 7 21 47 PM" src="https://github.com/user-attachments/assets/64108cea-55fa-412c-89f3-9ef74a7f4e98" />
