### PR TITLE
SUBMISSION-228: Review Files: improve the file list tree presentation.

### DIFF
--- a/submit_ce/ui/static/js/review_delete_cascade.js
+++ b/submit_ce/ui/static/js/review_delete_cascade.js
@@ -54,21 +54,34 @@
     });
   }
 
+  // Row tint follows the checkbox: yellow when marked for deletion, cleared
+  // when not. The server renders the initial tint for auto-checked (unused)
+  // files (SUBMISSION-228); this keeps it live as boxes toggle -- individually,
+  // via the folder cascade, or "Keep All".
+  function syncDeletionTints() {
+    fileCheckboxes().forEach(function (cb) {
+      var row = cb.closest("tr");
+      if (row) { row.classList.toggle("marked-for-deletion", cb.checked); }
+    });
+  }
+
+  function refresh() { syncDirStates(); syncDeletionTints(); }
+
   window.addEventListener("DOMContentLoaded", function () {
     dirCheckboxes().forEach(function (dir) {
       dir.addEventListener("change", function () {
         descendants(dir).forEach(function (cb) { cb.checked = dir.checked; });
-        syncDirStates();
+        refresh();
       });
     });
     fileCheckboxes().forEach(function (cb) {
-      cb.addEventListener("change", syncDirStates);
+      cb.addEventListener("change", refresh);
     });
     // "Keep All" unchecks boxes directly (no change event); resync afterward.
     document.querySelectorAll('.keep-all-link').forEach(function (link) {
-      link.addEventListener("click", function () { setTimeout(syncDirStates, 0); });
+      link.addEventListener("click", function () { setTimeout(refresh, 0); });
     });
-    // Initialise folder states from the server-rendered (auto-checked) files.
-    syncDirStates();
+    // Initialise folder states + tints from the server-rendered (auto-checked) files.
+    refresh();
   });
 })();

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -1,4 +1,8 @@
 {% extends "submit/base_edit.html" %}
+{# svg is imported in base_edit.html for the page blocks, but the
+   display_preflight_tree macro below has its own module namespace and doesn't
+   inherit that import -- so import it here too for svg.folder (SUBMISSION-228). #}
+{% import "svg.html" as svg %}
 
 {% block addl_head %}
 {{super()}}
@@ -9,6 +13,9 @@
    /* Oversized-image row highlight (SUBMISSION-172), mirroring 1.5's
       cream row tint. !important so it wins over the is-striped zebra shading. */
    .review-files-table tbody tr.is-oversized td { background-color: #fffbe6 !important; }
+   /* Rows auto-checked for deletion get a yellow tint (SUBMISSION-228),
+      mirroring 1.5. Declared after is-oversized so it wins when a row is both. */
+   .review-files-table tbody tr.marked-for-deletion td { background-color: #fff3cd !important; }
  </style>
 {% endblock addl_head %}
 
@@ -31,7 +38,9 @@
   {# Oversized-image rows get a cream tint (SUBMISSION-172), mirroring
      1.5. is_oversized is authoritative from preflight (large AND not
      pdftex-fast-copy). #}
-  <tr{% if item.is_oversized %} class="is-oversized"{% endif %}>
+  {# Rows auto-checked for deletion get a yellow tint (SUBMISSION-228),
+     mirroring 1.5; oversized images keep their cream tint. #}
+  <tr class="{% if item.is_unused %}marked-for-deletion {% endif %}{% if item.is_oversized %}is-oversized{% endif %}">
     <td class="has-text-centered">
       <input type="hidden" name="all_files" value="{{ item.filename }}">
       {% if item.is_readme %}
@@ -60,8 +69,10 @@
       {% endif %}
     </td>
     {# Image files show their size next to the name, MP to two decimals,
-       mirroring 1.5 (e.g. "figure.png (36.00 MP)"). (SUBMISSION-172) #}
-    <td>{{ item.filename }}{% if item.megapixels %} ({{ '%.2f'|format(item.megapixels) }} MP){% endif %}</td>
+       mirroring 1.5 (e.g. "figure.png (36.00 MP)"). (SUBMISSION-172)
+       Indent by directory depth (flat table has no nesting) so the file reads as
+       part of its folder subtree (SUBMISSION-228). #}
+    <td style="padding-left: {{ prefix.count('/') * 1.5 + 0.5 }}rem">{{ item.filename }}{% if item.megapixels %} ({{ '%.2f'|format(item.megapixels) }} MP){% endif %}</td>
     <td>
       {# Preflight issue badges (SUBMISSION-210), severity-colored, before the
          auto-detected usage note. #}
@@ -99,7 +110,12 @@
       <input type="checkbox" class="dir-delete" data-dir="{{ prefix }}{{ key }}/"
              aria-label="Select all deletable files in {{ prefix }}{{ key }}/ for deletion">
     </td>
-    <td colspan="2"><em>{{ key }}/</em></td>
+    {# Folder icon + bold name, indented by depth, matching the Upload page
+       (SUBMISSION-228); the Notes column labels it a Directory. #}
+    <td style="padding-left: {{ prefix.count('/') * 1.5 + 0.5 }}rem">
+      {{ svg.folder(klass="icon filter-blue") }} <strong>{{ key }}/</strong>
+    </td>
+    <td>Directory</td>
   </tr>
   {% for k, subitem in item.items() %}
     {{ display_preflight_tree(k, subitem, prefix ~ key ~ '/') }}


### PR DESCRIPTION
Review-page half of the file-list tree presentation parity with 1.5. Sibling of SUBMISSION-227 (Upload page).

**Change** (`review_files.html`, `review_delete_cascade.js`)
- Directory rows now render a **folder icon + bold folder name** and a "Directory" note in the Notes column, matching the Upload page.
- File rows are **indented by depth** (padding derived from the path prefix) so the folder structure reads at a glance.
- Rows auto-checked for deletion (unused files) get a **yellow tint**; the server renders the initial tint and a few lines of JS keep it live as boxes toggle — individually, via the folder cascade, or "Keep All".

Presentation only — no controller/logic change. The folder SVG + `folder()` macro land with SUBMISSION-227.

<img width="1385" height="1180" alt="ReviewFiles-2 0-FileListEnhancements-Screenshot 2026-08-12 at 2 21 44 PM" src="https://github.com/user-attachments/assets/3efd1727-39f4-4079-9f57-51d0f422b3ac" />
