### PR TITLE
SUBMISSION-231: Update the file list when the top-level TeX file changes.

### DIFF
--- a/submit_ce/implementations/compile/directive_manager.py
+++ b/submit_ce/implementations/compile/directive_manager.py
@@ -70,6 +70,54 @@ class DirectiveManager:
                         used.add(name)
         return used
 
+    def used_edges(preflight_data: dict) -> dict:
+        '''Adjacency list ``{tex_filename: [referenced filenames]}``.
+
+        Preflight's resolved-reference graph, flattened per tex file from
+        ``used_tex_files`` / ``used_other_files`` / ``used_bib_files``. Shared by
+        ``reachable_from`` (the server-side rooted walk) and embedded verbatim in
+        the Review Files page so the client-side live recompute walks the *same*
+        graph (SUBMISSION-231). One definition, two consumers.
+        '''
+        adjacency: dict = {}
+        for tex_file in (preflight_data or {}).get('tex_files', []):
+            name = tex_file.get('filename')
+            if not name:
+                continue
+            refs = adjacency.setdefault(name, [])
+            for key in ('used_tex_files', 'used_other_files', 'used_bib_files'):
+                refs.extend(r for r in tex_file.get(key, []) if r)
+        return adjacency
+
+    def reachable_from(roots, preflight_data: dict) -> set:
+        '''Files reachable from `roots` over preflight's resolved-edge graph.
+
+        The rooted counterpart of ``used_source_filenames``: instead of the flat
+        union of *every* tex file's resolved edges, walk the reference graph
+        starting from the selected top-level file(s) and return every file
+        transitively referenced. This is what lets the "used / not used"
+        classification change with the top-level selection (SUBMISSION-231)
+        **without re-running preflight** -- the edges are already in the report,
+        so re-rooting is just a graph traversal (consistent with SUBMISSION-215,
+        which keeps the report valid on selection-only changes).
+
+        Traversal is transitive (a used ``.tex`` may pull in further files). The
+        roots themselves are excluded from the result -- they are the selected
+        top-levels, classified separately (is_toplevel) and protected on their
+        own. Uses the same adjacency (`used_edges`) embedded for the client.
+        '''
+        adjacency = DirectiveManager.used_edges(preflight_data)
+        root_set = {r for r in (roots or []) if r}
+        used: set = set()
+        stack = list(root_set)
+        while stack:
+            node = stack.pop()
+            for ref in adjacency.get(node, ()):
+                if ref not in used and ref not in root_set:
+                    used.add(ref)
+                    stack.append(ref)  # transitive: a used file may reference more
+        return used
+
     def get_files_from_preflight(preflight_data: dict) -> list:
         files = {}
         # Object sections: each entry is a dict carrying a 'filename'.

--- a/submit_ce/implementations/tests/test_directive_manager.py
+++ b/submit_ce/implementations/tests/test_directive_manager.py
@@ -130,6 +130,67 @@ def test_used_source_filenames_unions_resolved_edges():
     assert dm.used_source_filenames({}) == set()
 
 
+# --- reachable_from: rooted reachability (SUBMISSION-231) -------------------
+
+_TWO_TOP_LEVELS = {"tex_files": [
+    {"filename": "main1.tex", "used_tex_files": ["chap1.tex"],
+     "used_other_files": ["shared.png"]},
+    {"filename": "chap1.tex", "used_other_files": ["fig1.png"]},
+    {"filename": "main2.tex", "used_tex_files": ["chap2.tex"],
+     "used_bib_files": ["refs.bib"]},
+    {"filename": "chap2.tex", "used_other_files": ["fig2.png"]},
+]}
+
+
+def test_reachable_from_is_rooted_at_selection():
+    """Only files reachable from the selected top-level count as used, and the
+    traversal is transitive (main1 -> chap1 -> fig1)."""
+    assert dm.reachable_from(["main1.tex"], _TWO_TOP_LEVELS) == {
+        "chap1.tex", "fig1.png", "shared.png"}
+    assert dm.reachable_from(["main2.tex"], _TWO_TOP_LEVELS) == {
+        "chap2.tex", "fig2.png", "refs.bib"}
+
+
+def test_reachable_from_multiple_roots_is_union():
+    both = dm.reachable_from(["main1.tex", "main2.tex"], _TWO_TOP_LEVELS)
+    assert both == (dm.reachable_from(["main1.tex"], _TWO_TOP_LEVELS)
+                    | dm.reachable_from(["main2.tex"], _TWO_TOP_LEVELS))
+
+
+def test_reachable_from_excludes_roots_and_handles_cycles():
+    # a <-> b cycle plus a self-reference must terminate and not include roots.
+    preflight = {"tex_files": [
+        {"filename": "a.tex", "used_tex_files": ["b.tex", "a.tex"]},
+        {"filename": "b.tex", "used_tex_files": ["a.tex"], "used_other_files": ["c.png"]},
+    ]}
+    assert dm.reachable_from(["a.tex"], preflight) == {"b.tex", "c.png"}
+
+
+def test_reachable_from_empty_roots_or_data():
+    assert dm.reachable_from([], _TWO_TOP_LEVELS) == set()
+    assert dm.reachable_from(["main1.tex"], {}) == set()
+    assert dm.reachable_from(None, None) == set()
+
+
+def test_used_edges_flattens_resolved_references():
+    """used_edges is the adjacency the client walk and reachable_from share:
+    {tex filename: [all referenced filenames]} (SUBMISSION-231)."""
+    edges = dm.used_edges(_TWO_TOP_LEVELS)
+    assert edges["main1.tex"] == ["chap1.tex", "shared.png"]
+    assert edges["chap1.tex"] == ["fig1.png"]
+    assert edges["main2.tex"] == ["chap2.tex", "refs.bib"]
+    assert dm.used_edges({}) == {}
+
+
+def test_reachable_from_uses_used_edges_graph():
+    """reachable_from is a BFS over exactly the used_edges adjacency."""
+    edges = dm.used_edges(_TWO_TOP_LEVELS)
+    # Everything reachable from main1 is a node/target present in the graph.
+    reach = dm.reachable_from(["main1.tex"], _TWO_TOP_LEVELS)
+    assert reach == {"chap1.tex", "shared.png", "fig1.png"}
+    assert set(edges["main1.tex"]) <= reach
+
+
 def test_get_files_from_preflight_tags_maybe_used():
     """Files from the maybe_used_files section are tagged is_maybe_used so the UI
     can tell them apart from truly-unused files (SUBMISSION-221 / C3.2a)."""

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -161,6 +161,7 @@ def review_files(method: str, params: MultiDict, session: Session,
         'selected_top_level_files': [],
         'top_level_candidates': [],
         'file_issues': {},
+        'recompute': {'edges': {}, 'candidates': [], 'maybe_used': []},
     }
 
     if not workspace:
@@ -275,11 +276,35 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     # instead of computing them inline (and re-deriving them from separate
     # file_issues / selected_top_level_files parameters). Gives a single
     # per-file object to extend with used/unused + delete defaults later.
+    #
+    # SUBMISSION-231: root "used" at the current top-level selection. The set of
+    # files reachable from the selected top-level(s) drives is_used/is_unused, so
+    # the auto-detected notes (and the auto-checked-for-deletion defaults) reflect
+    # THIS selection rather than a flat union over every tex file. No preflight
+    # re-run -- the edges are already in the report (see reachable_from).
+    used_filenames = dm.reachable_from(selected_top_level_files, preflight_data)
     rdata['file_notes'] = build_file_rows(
         dm.get_files_from_preflight(preflight_data),
         file_issues,
         selected_top_level_files,
+        used_filenames,
     )
+    # SUBMISSION-231 (part 2): data for the client-side live recompute. The same
+    # resolved-edge graph the server walked (used_edges), plus the detected
+    # top-level candidates and the coarse maybe-used set, so review_used_recompute.js
+    # can re-root used/unused in the browser as the top-level selection changes --
+    # display only, persisting/deleting nothing until Continue. Candidates are
+    # never auto-checked for deletion (a file the submitter might pick next).
+    rdata['recompute'] = {
+        'edges': dm.used_edges(preflight_data),
+        # Detected top-level files (the genuine alternative "mains"): never
+        # auto-check one for deletion, since the submitter might select it next.
+        # This is preflight's detected set, NOT every tex candidate in the dropdown.
+        'candidates': [t.get('filename') for t
+                       in (preflight_data.get('detected_toplevel_files') or [])
+                       if t.get('filename')],
+        'maybe_used': [f for f in (preflight_data.get('maybe_used_files') or []) if f],
+    }
     rdata['has_blocking_issues'] = any(
         n.get('severity') == 'danger' for n in issue_notifications)
     # SUBMISSION-218: collapse the per-code issue banners into one card
@@ -358,13 +383,19 @@ def _update_preflight(params: MultiDict, submission_id: str, workspace: Workspac
     files_to_delete = [p for p in params.getlist('selected_files') if p in existing_paths]
 
     # Never delete files the submission needs: the selected top-level TeX
-    # file(s) (SUBMISSION-209) and any file preflight resolved a reference to
-    # (SUBMISSION-221). maybe-used and unused files stay deletable. The
-    # template disables these checkboxes, but a crafted or stale POST can still
-    # carry them, so we filter here and warn. The authoritative guard is in
-    # SetDecisions.execute, which runs under the submission row lock.
+    # file(s) (SUBMISSION-209) and any file needed by that selection
+    # (SUBMISSION-221 / SUBMISSION-231). maybe-used and unused files stay
+    # deletable. The template disables these checkboxes, but a crafted or stale
+    # POST can still carry them, so we filter here and warn. The authoritative
+    # guard is in SetDecisions.execute (via protected_sources), which runs under
+    # the submission row lock.
+    #
+    # "used" is rooted at the top-level(s) being saved (SUBMISSION-231): a file
+    # protected because it's reachable from the OLD top-level should become
+    # deletable once the submitter switches away from it. reachable_from re-roots
+    # over the existing preflight edges -- no re-scan.
     selected_top_levels = _selected_top_level_files(params)
-    used_files = dm.used_source_filenames(_get_preflight_data(submission_id) or {})
+    used_files = dm.reachable_from(selected_top_levels, _get_preflight_data(submission_id) or {})
     protected_set = set(selected_top_levels) | used_files
     protected = [p for p in files_to_delete if p in protected_set]
     if protected:

--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -16,7 +16,7 @@ Pure transform -- no I/O.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 # The build-directives file: not a deletion candidate, and it gets a dedicated
 # note rather than a usage line.
@@ -27,6 +27,7 @@ def build_file_rows(
     file_notes: List[Dict[str, Any]],
     file_issues: Optional[Dict[str, List[Dict[str, str]]]],
     selected_top_level_files: List[str],
+    used_filenames: Optional[Set[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Return the preflight file list enriched for the Review Files table.
 
@@ -37,7 +38,12 @@ def build_file_rows(
       list when the file has none);
     * ``is_readme`` -- ``True`` for ``00README.json`` (build-directives file);
     * ``is_toplevel`` -- ``True`` when the file is a selected top-level TeX file;
-    * ``is_used`` -- an ordinary file preflight resolved a reference to;
+    * ``is_used`` -- an ordinary file that is *needed by the selected top-level(s)*.
+      When ``used_filenames`` is given (SUBMISSION-231) this is rooted membership
+      in that set -- the files reachable from the selected top-level(s), so the
+      classification changes as the selection changes. When it is ``None`` (older
+      callers/tests) it falls back to "preflight resolved any reference to it"
+      (the ``used_by*`` reverse edges), the pre-231 behavior;
     * ``is_maybe_used`` -- an ordinary file only in the coarse ``maybe_used_files``
       guess bucket (rendered "Possibly used");
     * ``is_unused`` -- an ordinary file nothing references (rendered "Not used");
@@ -64,15 +70,25 @@ def build_file_rows(
         row["is_readme"] = filename == README_FILENAME
         row["is_toplevel"] = filename in top_levels
         # Usage classification (SUBMISSION-221 / C3.2a), by descending confidence:
-        #   is_used       -- preflight resolved a reference to it (used_by* edges);
+        #   is_used       -- needed by the selected top-level(s);
         #   is_maybe_used -- only in the coarse maybe_used_files guess bucket;
         #   is_unused     -- nothing references it at all ("Not used").
         # A resolved edge wins over the maybe-used flag. The 00README and a
         # selected top-level are handled separately and are none of these.
+        #
+        # "used" is rooted at the current selection when `used_filenames` is
+        # supplied (SUBMISSION-231): membership in the set of files reachable
+        # from the selected top-level(s), so the note flips as the top-level
+        # changes. Without it (older callers), fall back to the flat "referenced
+        # by any tex file" signal (the used_by* reverse edges) -- the pre-231
+        # behavior, preserved so existing callers/tests are unaffected.
         raw_maybe_used = bool(row.get("is_maybe_used"))
-        used_refs = bool(row.get("used_by")
-                         or row.get("used_by_tex")
-                         or row.get("used_by_bib"))
+        if used_filenames is not None:
+            used_refs = filename in used_filenames
+        else:
+            used_refs = bool(row.get("used_by")
+                             or row.get("used_by_tex")
+                             or row.get("used_by_bib"))
         ordinary = not row["is_readme"] and not row["is_toplevel"]
         row["is_used"] = ordinary and used_refs
         row["is_maybe_used"] = ordinary and not used_refs and raw_maybe_used

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -101,6 +101,41 @@ def test_is_unused_only_for_unreferenced_ordinary_files():
     assert by_name["fig.png"]["is_unused"] is False
 
 
+def test_used_is_rooted_at_selection_when_used_filenames_given():
+    """With `used_filenames` (the rooted reachable set), a file's used/unused
+    note follows the current top-level selection, not a flat union of every
+    reference (SUBMISSION-231). Same files, two selections, opposite results."""
+    notes = [
+        {"filename": "main1.tex"},
+        {"filename": "main2.tex"},
+        {"filename": "only1.png", "used_by": ["main1.tex"]},
+        {"filename": "only2.png", "used_by": ["main2.tex"]},
+    ]
+    # main1 selected: reachable set is {only1.png}
+    by1 = {r["filename"]: r for r in
+           build_file_rows(notes, {}, ["main1.tex"], {"only1.png"})}
+    assert by1["only1.png"]["is_used"] and by1["only1.png"]["is_protected"]
+    assert by1["only2.png"]["is_unused"] and not by1["only2.png"]["is_protected"]
+
+    # main2 selected: the very same only2.png flips to used/protected.
+    by2 = {r["filename"]: r for r in
+           build_file_rows(notes, {}, ["main2.tex"], {"only2.png"})}
+    assert by2["only2.png"]["is_used"] and by2["only2.png"]["is_protected"]
+    assert by2["only1.png"]["is_unused"] and not by2["only1.png"]["is_protected"]
+
+
+def test_empty_used_filenames_marks_all_ordinary_unused():
+    """An empty rooted set (e.g. no top-level yet selected, or nothing reachable)
+    is distinct from None: every ordinary file is 'not used' even if it carries
+    reverse-edge data."""
+    notes = [
+        {"filename": "main.tex"},
+        {"filename": "fig.png", "used_by": ["main.tex"]},
+    ]
+    by = {r["filename"]: r for r in build_file_rows(notes, {}, ["main.tex"], set())}
+    assert by["fig.png"]["is_unused"] and not by["fig.png"]["is_used"]
+
+
 def test_none_issues_and_none_selection_are_safe():
     rows = build_file_rows(_notes(), None, None)
     assert all(r["badges"] == [] and r["is_toplevel"] is False for r in rows)

--- a/submit_ce/ui/static/js/review_used_recompute.js
+++ b/submit_ce/ui/static/js/review_used_recompute.js
@@ -1,0 +1,168 @@
+// review_used_recompute.js  (SUBMISSION-231, part 2)
+//
+// Live, client-side recompute of each file's used / not-used state as the
+// top-level TeX selection changes -- WITHOUT a server round-trip and WITHOUT
+// deleting or persisting anything. Deletion still happens only when the
+// submitter clicks Continue with their final selection.
+//
+// Why this exists: "used" is not a fixed property of a file; it's reachability
+// from the *selected* top-level(s) over preflight's resolved-reference graph
+// (see DirectiveManager.reachable_from / used_edges, SUBMISSION-231). The server
+// renders the correct state for the initial selection and re-derives it
+// authoritatively on Continue; this script mirrors that same walk in the
+// browser so the "Auto-detected Notes" and the delete checkboxes update the
+// instant the submitter changes the top-level -- important because a large
+// submission's server render is far too slow to round-trip on every change.
+//
+// It supersedes the partial top-level guard (SUBMISSION-209) by running last
+// and setting the complete per-row state (top-level / used / candidate /
+// possibly-used / unused). With JS off, the server render still applies.
+//
+// PARITY: reachableFrom() below must stay behaviourally identical to the Python
+// DirectiveManager.reachable_from(). A shared fixture asserts they agree
+// (see the parity test).
+(function () {
+  "use strict";
+
+  function readData() {
+    var el = document.getElementById("review-recompute-data");
+    if (!el) { return null; }
+    try { return JSON.parse(el.textContent || "{}"); }
+    catch (e) { return null; }
+  }
+
+  // Files reachable from `roots` over the adjacency `edges`
+  // ({filename: [referenced...]}), transitively, excluding the roots
+  // themselves. Mirror of DirectiveManager.reachable_from.
+  function reachableFrom(roots, edges) {
+    var rootSet = {};
+    (roots || []).forEach(function (r) { if (r) { rootSet[r] = true; } });
+    var used = {};
+    var stack = Object.keys(rootSet);
+    while (stack.length) {
+      var node = stack.pop();
+      var refs = (edges && edges[node]) || [];
+      for (var i = 0; i < refs.length; i++) {
+        var ref = refs[i];
+        if (ref && !used[ref] && !rootSet[ref]) {
+          used[ref] = true;
+          stack.push(ref);
+        }
+      }
+    }
+    return used;  // set-as-object: {filename: true}
+  }
+
+  function topLevelSelects() {
+    return document.querySelectorAll(
+      'select[name="source_file"], select[name="top_level_tex_files[]"]');
+  }
+
+  function selectedTopLevels() {
+    var out = [];
+    topLevelSelects().forEach(function (sel) {
+      if (sel.value && out.indexOf(sel.value) === -1) { out.push(sel.value); }
+    });
+    return out;
+  }
+
+  function fileCheckboxes() {
+    return document.querySelectorAll('input[name="selected_files"]');
+  }
+
+  function setNote(cb, text) {
+    var row = cb.closest("tr");
+    var note = row && row.querySelector(".file-usage-note");
+    if (note) { note.textContent = text; }
+  }
+
+  function setTint(cb) {
+    var row = cb.closest("tr");
+    // The yellow marked-for-deletion tint (styled by SUBMISSION-228) follows the
+    // checkbox; no-op visually on branches without that CSS.
+    if (row) { row.classList.toggle("marked-for-deletion", cb.checked); }
+  }
+
+  // Pure per-file decision, given the current selection state. Returns the DOM
+  // state to apply: {disabled, checked, lock (or null), note}. Mirrors the
+  // server-side build_file_rows classification (SUBMISSION-220/221/222/231),
+  // with the added rule that a detected-but-unselected top-level is never
+  // auto-checked. Kept pure so it can be unit-tested without a DOM.
+  function classify(fn, sets) {
+    if (sets.rootSet[fn]) {
+      // Selected top-level: what we compile -- not deletable.
+      return { disabled: true, checked: false, lock: null, note: "Used: top-level file" };
+    }
+    if (sets.used[fn]) {
+      // Needed by the current selection: protected from deletion here.
+      return { disabled: true, checked: false, lock: "used", note: "Used" };
+    }
+    if (sets.candidateSet[fn]) {
+      // Detected top-level the submitter hasn't selected: deletable, but never
+      // auto-checked -- they may pick it next.
+      return { disabled: false, checked: false, lock: null, note: "Not used" };
+    }
+    if (sets.maybeSet[fn]) {
+      // Coarse "possibly used" guess: deletable but not suggested.
+      return { disabled: false, checked: false, lock: null, note: "Possibly used" };
+    }
+    // Nothing in the current selection references it: pre-check for deletion
+    // (mirrors the server auto-check, SUBMISSION-222). Nothing is deleted until
+    // Continue.
+    return { disabled: false, checked: true, lock: null, note: "Not used" };
+  }
+
+  function buildSets(data, roots) {
+    var candidateSet = {};
+    ((data && data.candidates) || []).forEach(function (f) { candidateSet[f] = true; });
+    var maybeSet = {};
+    ((data && data.maybe_used) || []).forEach(function (f) { maybeSet[f] = true; });
+    var rootSet = {};
+    (roots || []).forEach(function (r) { rootSet[r] = true; });
+    return {
+      rootSet: rootSet,
+      used: reachableFrom(roots, (data && data.edges) || {}),
+      candidateSet: candidateSet,
+      maybeSet: maybeSet,
+    };
+  }
+
+  function recompute(data) {
+    var sets = buildSets(data, selectedTopLevels());
+    fileCheckboxes().forEach(function (cb) {
+      // 00README is permanently locked server-side; never touch it.
+      if (cb.dataset.lock === "permanent") { return; }
+      var s = classify(cb.value, sets);
+      cb.disabled = s.disabled;
+      cb.checked = s.checked;
+      if (s.lock) { cb.dataset.lock = s.lock; } else { delete cb.dataset.lock; }
+      setNote(cb, s.note);
+      setTint(cb);
+    });
+  }
+
+  if (typeof window !== "undefined") { window.addEventListener("DOMContentLoaded", function () {
+    var data = readData();
+    if (!data) { return; }  // no graph -> leave the server render as-is
+    // Re-run on any top-level change. The multi-select widget
+    // (review_top_level_select.js) dispatches a change on the first select
+    // after add/remove/reorder, so that path is covered too.
+    topLevelSelects().forEach(function (sel) {
+      sel.addEventListener("change", function () { recompute(data); });
+    });
+    document.addEventListener("change", function (e) {
+      if (e.target && e.target.classList &&
+          e.target.classList.contains("top-level-select")) {
+        recompute(data);
+      }
+    });
+    // Establish a consistent state on load (also unchecks any detected
+    // top-level candidate the server pre-checked).
+    recompute(data);
+  }); }
+
+  // Exported for the parity/classification tests (Node). No effect in browser.
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = { reachableFrom: reachableFrom, classify: classify, buildSets: buildSets };
+  }
+})();

--- a/submit_ce/ui/static/js/tests/review_used_recompute.test.js
+++ b/submit_ce/ui/static/js/tests/review_used_recompute.test.js
@@ -1,0 +1,76 @@
+// Node test for review_used_recompute.js (SUBMISSION-231 part 2).
+// No DOM / test runner needed -- run with:  node review_used_recompute.test.js
+// Exits non-zero on failure. Covers (a) the reachability walk and (b) the pure
+// per-file classify() decision, including the safety rule that a detected but
+// unselected top-level is never auto-checked for deletion.
+//
+// PARITY: reachableFrom() here must match DirectiveManager.reachable_from() in
+// submit_ce/implementations/compile/directive_manager.py -- the Python unit
+// tests assert the same expected sets on the same graph.
+
+const assert = require("assert");
+const { reachableFrom, classify, buildSets } =
+  require("../review_used_recompute.js");
+
+// Two independent top-levels with disjoint subtrees + a shared file + a guess.
+const DATA = {
+  edges: {
+    "main1.tex": ["chap1.tex", "shared.png"],
+    "chap1.tex": ["fig1.png"],
+    "main2.tex": ["chap2.tex", "refs.bib"],
+    "chap2.tex": ["fig2.png"],
+  },
+  candidates: ["main1.tex", "main2.tex"],
+  maybe_used: ["guess.sty"],
+};
+
+function keys(setObj) { return Object.keys(setObj).sort(); }
+
+// --- reachability (mirror of Python reachable_from) ---
+assert.deepStrictEqual(
+  keys(reachableFrom(["main1.tex"], DATA.edges)),
+  ["chap1.tex", "fig1.png", "shared.png"]);
+assert.deepStrictEqual(
+  keys(reachableFrom(["main2.tex"], DATA.edges)),
+  ["chap2.tex", "fig2.png", "refs.bib"]);
+assert.deepStrictEqual(
+  keys(reachableFrom(["main1.tex", "main2.tex"], DATA.edges)),
+  ["chap1.tex", "chap2.tex", "fig1.png", "fig2.png", "refs.bib", "shared.png"]);
+// cycle-safe, roots excluded
+assert.deepStrictEqual(
+  keys(reachableFrom(["a"], { a: ["b", "a"], b: ["a", "c"] })), ["b", "c"]);
+assert.deepStrictEqual(keys(reachableFrom([], DATA.edges)), []);
+
+// --- classify() decisions ---
+function state(fn, roots) {
+  const s = classify(fn, buildSets(DATA, roots));
+  return { disabled: s.disabled, checked: s.checked, note: s.note };
+}
+
+// main1 selected
+assert.deepStrictEqual(state("main1.tex", ["main1.tex"]),
+  { disabled: true, checked: false, note: "Used: top-level file" });
+assert.deepStrictEqual(state("fig1.png", ["main1.tex"]),
+  { disabled: true, checked: false, note: "Used" });
+// detected candidate, unselected -> NOT auto-checked (safety)
+assert.deepStrictEqual(state("main2.tex", ["main1.tex"]),
+  { disabled: false, checked: false, note: "Not used" });
+// genuinely unused -> auto-checked
+assert.deepStrictEqual(state("fig2.png", ["main1.tex"]),
+  { disabled: false, checked: true, note: "Not used" });
+assert.deepStrictEqual(state("guess.sty", ["main1.tex"]),
+  { disabled: false, checked: false, note: "Possibly used" });
+
+// main2 selected -> the halves swap
+assert.deepStrictEqual(state("main1.tex", ["main2.tex"]),
+  { disabled: false, checked: false, note: "Not used" });
+assert.deepStrictEqual(state("fig2.png", ["main2.tex"]),
+  { disabled: true, checked: false, note: "Used" });
+
+// both selected -> nothing unused
+assert.deepStrictEqual(state("chap1.tex", ["main1.tex", "main2.tex"]),
+  { disabled: true, checked: false, note: "Used" });
+assert.deepStrictEqual(state("chap2.tex", ["main1.tex", "main2.tex"]),
+  { disabled: true, checked: false, note: "Used" });
+
+console.log("review_used_recompute.test.js: all assertions passed");

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -6,6 +6,7 @@
  <script src="{{ url_for('static', filename='js/review_top_level_guard.js') }}" defer></script>
  <script src="{{ url_for('static', filename='js/review_top_level_select.js') }}" defer></script>
  <script src="{{ url_for('static', filename='js/review_delete_cascade.js') }}" defer></script>
+ <script src="{{ url_for('static', filename='js/review_used_recompute.js') }}" defer></script>
  <style>
    /* Oversized-image row highlight (SUBMISSION-172), mirroring 1.5's
       cream row tint. !important so it wins over the is-striped zebra shading. */
@@ -70,6 +71,11 @@
       {% if file_issue_list %}
         {% for issue in file_issue_list %}<span class="tag is-{{ issue.severity }}">{{ issue.label }}</span> {% endfor %}<br>
       {% endif %}
+      {# The usage note is wrapped in a span the client-side recompute updates
+         in place as the top-level selection changes (SUBMISSION-231 part 2).
+         The server render is authoritative on load and on Continue; the JS only
+         re-labels for live feedback. #}
+      <span class="file-usage-note">
       {% if item.is_readme %}
         Build directives file
       {% elif item.is_toplevel %}
@@ -78,6 +84,7 @@
         {% if item.used_by %}Used by: {{ item.used_by | join(', ') }}<br>{% endif %}
         {% if item.used_by_tex %}Used by (TeX): {{ item.used_by_tex | join(', ') }}<br>{% endif %}
         {% if item.used_by_bib %}Used by (bib): {{ item.used_by_bib | join(', ') }}{% endif %}
+        {% if not (item.used_by or item.used_by_tex or item.used_by_bib) %}Used{% endif %}
       {% elif item.is_maybe_used %}
         {# In preflight's coarse maybe_used_files guess -- kept but no resolved
            reference. Deletable but not suggested (SUBMISSION-221 / C3.2a). #}
@@ -86,6 +93,7 @@
         {# Nothing references this file (SUBMISSION-220). #}
         Not used
       {% endif %}
+      </span>
     </td>
   </tr>
   {% else %}
@@ -212,6 +220,12 @@
       method="POST" enctype="multipart/form-data">
   <div class="action-container">
     {{ form.csrf_token }}
+
+    {# Resolved-reference graph + candidate/maybe-used sets for the client-side
+       live recompute (SUBMISSION-231 part 2). review_used_recompute.js reads
+       this to re-root used/unused in the browser as the top-level selection
+       changes -- no server round-trip, and nothing is deleted until Continue. #}
+    <script type="application/json" id="review-recompute-data">{{ recompute | tojson }}</script>
 
   {# Compiler engine + TeX Live version (auto-selected from preflight) #}
   <div class="field">


### PR DESCRIPTION
Summary:

Update the Review Files list when the top-level TeX file changes: a file's
"used / not used" state is reachability from the *selected* top-level(s), so it
must change as the selection changes.

Details:

**Background**
"Used" was a flat union of every tex file's resolved references, independent of
which top-level was selected — so the auto-detected notes never updated when the
submitter changed the top-level. Preflight already carries the full
resolved-reference graph, so re-rooting is a graph walk, not a re-scan (stays
consistent with SUBMISSION-215, which keeps the preflight report valid on
selection-only changes).

**Part 1 — server (authoritative)**
- `DirectiveManager.used_edges()` — the resolved-reference adjacency
  `{tex file: [referenced files]}`.
- `DirectiveManager.reachable_from(roots, preflight)` — files transitively
  reachable from the selected top-level(s); the rooted counterpart of the flat
  `used_source_filenames`.
- `build_file_rows(..., used_filenames)` roots `is_used` / `is_unused` /
  `is_protected` in that set (falls back to the old reverse-edge behavior when
  the set is omitted, so existing callers are unaffected).
- `review.py` passes the rooted set to the row builder and uses it for the
  delete guard's `protected_sources`, so a file protected because the *old*
  top-level needed it becomes deletable once the submitter switches away.

**Part 2 — client (live, display-only)**
- `review.py` embeds the graph + detected top-level candidates + the coarse
  maybe-used set as JSON in the page.
- `review_used_recompute.js` walks that graph with the same logic as
  `reachable_from` and re-labels each row + updates its delete checkbox the
  instant the top-level selection changes — no server round-trip. It persists
  and deletes **nothing**; deletion still happens only on Continue with the
  final selection. (A round-trip trigger was rejected: it would couple the
  selection with the auto-delete of unused files and drop files needed by the
  other top-level.)
- A detected-but-unselected top-level is labeled "Not used" but is **never**
  auto-checked for deletion — the submitter may pick it next.

**How to keep multiple top-levels:** select them all in the top-level widget;
every subtree is then "used" and nothing is auto-checked.

**Tests**
- `test_directive_manager.py`: `used_edges`, `reachable_from` (rooted, union,
  cycles, empty).
- `test_file_context.py`: a file flips Used↔Not-used purely by changing the
  selection; empty-set vs None distinction.
- `static/js/tests/review_used_recompute.test.js` (run with `node`): the JS walk
  matches the Python one, and the per-file `classify()` decisions across
  main-A / main-B / both selections, including the "never auto-check an
  unselected candidate" safety rule. Parity was checked on a real 462-file
  two-top-level submission.

**Follow-ups (not in this PR)**
- No-JS parity: the server still pre-checks an unselected detected top-level;
  a small refinement (pass the detected candidates into `build_file_rows` and
  don't auto-check them) would close that for JavaScript-disabled users.
- The yellow marked-for-deletion tint + delete-cascade refresh land with the
  file-tree presentation work; reconcile when this branch rebases onto develop.

<img width="1016" height="946" alt="ReviewFiles-2 0-Baseline-Screenshot 2026-08-18 at 11 21 37 AM" src="https://github.com/user-attachments/assets/0a447eb8-0507-4e86-8628-646e6cc90969" />

<img width="1040" height="923" alt="ReviewFiles-2 0-RemoveTopLevelTeXfile-Screenshot 2026-08-18 at 11 22 02 AM" src="https://github.com/user-attachments/assets/57a3bd3a-52ad-4828-b8a1-f88775de2e64" />
