### PR TITLE
SUBMISSION-233: Fix delete_all_source_files aborting on the first already-removed object

### DIFF
--- a/submit_ce/implementations/file_store/gs_file_store.py
+++ b/submit_ce/implementations/file_store/gs_file_store.py
@@ -411,9 +411,7 @@ class GsFileStore(SubmissionFileStore, FileStoreMixin):
 
     @override
     def delete_workspace(self, submission_id: str) -> None:
-        blobs = self.bucket.list_blobs(prefix=self._source_path(submission_id))
-        for blob in blobs:
-            blob.delete()
+        self._delete_blobs_under(self._source_path(submission_id))
 
     @override
     def is_available(self) -> bool:
@@ -426,9 +424,22 @@ class GsFileStore(SubmissionFileStore, FileStoreMixin):
 
     @override
     def delete_all_source_files(self, submission_id: str) -> None:
-        blobs = self.bucket.list_blobs(prefix=self._source_path(submission_id))
-        for blob in blobs:
-            blob.delete()
+        self._delete_blobs_under(self._source_path(submission_id))
+
+    def _delete_blobs_under(self, prefix: str) -> None:
+        """Delete every object under `prefix`, idempotently.
+
+        Uses ``delete_blobs`` with an ``on_error`` that ignores per-object
+        NotFound, so an already-removed object doesn't abort the whole
+        operation. Deleting a file set is meant to be idempotent: a retried or
+        interrupted "delete all" over a slow link would otherwise 404 on the
+        objects the first pass already removed (the bug this fixes). A bare
+        ``blob.delete()`` loop raised on the first missing object and left the
+        rest undeleted.
+        """
+        blobs = list(self.bucket.list_blobs(prefix=prefix))
+        if blobs:
+            self.bucket.delete_blobs(blobs, on_error=lambda blob: None)
 
     @override
     def delete_preview(self, submission_id: str) -> None:

--- a/submit_ce/implementations/file_store/tests/test_gs_file_store.py
+++ b/submit_ce/implementations/file_store/tests/test_gs_file_store.py
@@ -5,6 +5,7 @@ Run with: TEST_GS_FILE_STORE_AT_GCP=1 uv run pytest submit_ce/implementations/fi
 """
 import json
 import os
+import posixpath
 import tarfile
 import uuid
 from io import BytesIO
@@ -227,6 +228,25 @@ def test_delete_workspace(store, sub_id):
 
     ws = store.get_workspace(sub_id)
     assert ws.files == []
+
+
+def test_delete_all_source_files_ignores_already_removed(store, sub_id):
+    """Delete-all must be idempotent: an object that's already gone (e.g. a
+    retried/interrupted delete over a slow link) must not abort the rest with a
+    404. Simulate by deleting one object out from under the store, then
+    delete-all, then delete-all again. (SUBMISSION-233)"""
+    store.store_source_file(sub_id, FakeFile("a.tex", b"a"), chunk_size=4096)
+    store.store_source_file(sub_id, FakeFile("b.tex", b"b"), chunk_size=4096)
+    store.store_source_file(sub_id, FakeFile("c.tex", b"c"), chunk_size=4096)
+
+    # Remove one object directly so the next list-then-delete hits a NotFound.
+    store.bucket.blob(posixpath.join(store._source_path(sub_id), "b.tex")).delete()
+
+    store.delete_all_source_files(sub_id)          # must not raise on the 404
+    assert store.get_workspace(sub_id).files == []
+
+    store.delete_all_source_files(sub_id)          # already empty -> clean no-op
+    assert store.get_workspace(sub_id).files == []
 
 
 def test_is_available(store):


### PR DESCRIPTION
**Summary:

Deleting all source files aborts on the first already-removed object.

**Problem**
`GsFileStore.delete_all_source_files()` and `delete_workspace()` list every
object under the submission's source prefix and call `blob.delete()` in a plain
loop with no error handling. If any single object is already gone at delete
time, GCS raises `NotFound` (404), which propagates and aborts the whole
operation — the remaining objects are left undeleted and the request 500s.
Deletion isn't idempotent, so a retried/interrupted "Remove All" over a
high-latency connection (dev-on-laptop against the dev bucket, or a transient
production retry) 404s on the objects the first pass already removed.

**Fix**
Route both methods through a single `_delete_blobs_under(prefix)` helper that
uses `bucket.delete_blobs(blobs, on_error=lambda blob: None)`. The
google-cloud-storage `on_error` callback is invoked for per-object `NotFound`
instead of raising, so an already-absent object is a no-op and the rest of the
delete proceeds. Deleting a file set that's meant to disappear is idempotent by
definition. (`on_error` is not supported in a `Batch` context, so this is a
plain call.)

**Behavior after**
- Delete-all / workspace teardown succeeds even when some listed objects are
  already gone; no 404/500 surfaces.
- No objects remain under the submission's source prefix afterward.
- Re-running the delete is a clean no-op.

Independent of the Review Files parity work; touches only the two delete methods
in `gs_file_store.py`.
