### PR TITLE
SUBMISSION-244: Protect unselected top-level candidates from default delete (no-JS safety)

### DIFF
--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -283,11 +283,21 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     # THIS selection rather than a flat union over every tex file. No preflight
     # re-run -- the edges are already in the report (see reachable_from).
     used_filenames = dm.reachable_from(selected_top_level_files, preflight_data)
+    # Preflight-detected top-level files (the genuine alternative "mains"). An
+    # unselected one must never be auto-checked for deletion -- the submitter may
+    # pick it next. Passed to build_file_rows so the server render (the no-JS
+    # path) leaves it unchecked, matching the client-side recompute
+    # (SUBMISSION-244). NOT every tex candidate in the dropdown -- just the
+    # detected set.
+    detected_toplevels = [t.get('filename') for t
+                          in (preflight_data.get('detected_toplevel_files') or [])
+                          if t.get('filename')]
     rdata['file_notes'] = build_file_rows(
         dm.get_files_from_preflight(preflight_data),
         file_issues,
         selected_top_level_files,
         used_filenames,
+        set(detected_toplevels),
     )
     # SUBMISSION-231 (part 2): data for the client-side live recompute. The same
     # resolved-edge graph the server walked (used_edges), plus the detected
@@ -297,12 +307,7 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     # never auto-checked for deletion (a file the submitter might pick next).
     rdata['recompute'] = {
         'edges': dm.used_edges(preflight_data),
-        # Detected top-level files (the genuine alternative "mains"): never
-        # auto-check one for deletion, since the submitter might select it next.
-        # This is preflight's detected set, NOT every tex candidate in the dropdown.
-        'candidates': [t.get('filename') for t
-                       in (preflight_data.get('detected_toplevel_files') or [])
-                       if t.get('filename')],
+        'candidates': detected_toplevels,
         'maybe_used': [f for f in (preflight_data.get('maybe_used_files') or []) if f],
     }
     rdata['has_blocking_issues'] = any(

--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -28,6 +28,7 @@ def build_file_rows(
     file_issues: Optional[Dict[str, List[Dict[str, str]]]],
     selected_top_level_files: List[str],
     used_filenames: Optional[Set[str]] = None,
+    toplevel_candidates: Optional[Set[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Return the preflight file list enriched for the Review Files table.
 
@@ -46,9 +47,22 @@ def build_file_rows(
       (the ``used_by*`` reverse edges), the pre-231 behavior;
     * ``is_maybe_used`` -- an ordinary file only in the coarse ``maybe_used_files``
       guess bucket (rendered "Possibly used");
-    * ``is_unused`` -- an ordinary file nothing references (rendered "Not used");
+    * ``is_unused`` -- an ordinary file nothing references (rendered "Not used").
+      Auto-checked for deletion by the template -- EXCEPT for an unselected
+      detected top-level candidate (see ``toplevel_candidates``), which is left
+      unchecked;
     * ``is_protected`` -- must not be deleted here (readme, selected top-level, or
       confidently-used); drives the disabled delete checkbox.
+
+    ``toplevel_candidates`` (SUBMISSION-244) is the set of preflight-detected
+    top-level TeX files. A detected candidate the submitter has NOT selected is a
+    plausible alternative "main" they may pick next, so it must never be
+    *auto-checked* for deletion even when nothing currently references it: for
+    such a file ``is_unused`` is cleared (it renders "Not used" but unchecked and
+    still deletable). This mirrors the client-side live recompute and, crucially,
+    protects the JavaScript-disabled path -- where nothing would otherwise
+    uncheck it before Continue and the delete guard doesn't cover an unselected
+    candidate.
 
     ``is_readme`` / ``is_toplevel`` / ``is_used`` / ``is_maybe_used`` / ``is_unused``
     are mutually exclusive and drive the usage note; ``is_protected`` drives the
@@ -93,6 +107,14 @@ def build_file_rows(
         row["is_used"] = ordinary and used_refs
         row["is_maybe_used"] = ordinary and not used_refs and raw_maybe_used
         row["is_unused"] = ordinary and not used_refs and not raw_maybe_used
+        # An unselected detected top-level candidate is a plausible alternative
+        # "main" the submitter may pick next -- never auto-check it for deletion,
+        # even when unreferenced. Clear is_unused so the template renders it
+        # "Not used" but UNCHECKED; it stays deletable if the submitter opts in.
+        # Protects the no-JS path (SUBMISSION-244 / SUBMISSION-231).
+        if (toplevel_candidates and row["is_unused"]
+                and filename in toplevel_candidates):
+            row["is_unused"] = False
         # Protected from deletion (C3.2a): the 00README, a selected top-level, or
         # a confidently-used file. maybe-used and unused files stay deletable.
         row["is_protected"] = row["is_readme"] or row["is_toplevel"] or row["is_used"]

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -124,6 +124,40 @@ def test_used_is_rooted_at_selection_when_used_filenames_given():
     assert by2["only1.png"]["is_unused"] and not by2["only1.png"]["is_protected"]
 
 
+def test_unselected_toplevel_candidate_not_auto_checked():
+    """A detected top-level the submitter hasn't selected must NOT be auto-checked
+    for deletion (is_unused cleared), while a plain unused file still is. Protects
+    the no-JS path (SUBMISSION-244). Both remain deletable (not protected)."""
+    notes = [
+        {"filename": "main1.tex"},   # selected top-level
+        {"filename": "main2.tex"},   # detected candidate, NOT selected
+        {"filename": "orphan.png"},  # plain unused, not a candidate
+    ]
+    by = {r["filename"]: r for r in build_file_rows(
+        notes, {}, ["main1.tex"],
+        used_filenames=set(),                       # nothing reachable
+        toplevel_candidates={"main1.tex", "main2.tex"},
+    )}
+
+    # Selected top-level: handled as top-level, not unused.
+    assert by["main1.tex"]["is_toplevel"] and not by["main1.tex"]["is_unused"]
+    # Unselected candidate: "Not used" but NOT auto-checked (is_unused cleared),
+    # and still deletable (not protected).
+    assert by["main2.tex"]["is_unused"] is False
+    assert by["main2.tex"]["is_protected"] is False
+    # Plain unused non-candidate: auto-checked as usual.
+    assert by["orphan.png"]["is_unused"] is True
+
+
+def test_toplevel_candidates_omitted_keeps_auto_check():
+    """Without toplevel_candidates (older callers), an unreferenced file is still
+    is_unused -- the pre-244 behavior is unchanged."""
+    notes = [{"filename": "main1.tex"}, {"filename": "main2.tex"}]
+    by = {r["filename"]: r for r in build_file_rows(
+        notes, {}, ["main1.tex"], used_filenames=set())}
+    assert by["main2.tex"]["is_unused"] is True
+
+
 def test_empty_used_filenames_marks_all_ordinary_unused():
     """An empty rooted set (e.g. no top-level yet selected, or nothing reachable)
     is distinct from None: every ordinary file is 'not used' even if it carries


### PR DESCRIPTION
** Summary**
This ticket addresses an issue that arises when Javascript is disabled. This helps the submitter avoid inadvertently deleting unused files before they have a chance to select them. No-Javascript safety follow-up to SUBMISSION-231.

**Problem**
On the Review Files server render, a detected top-level TeX file the submitter
has NOT selected (e.g. `main2.tex` while `main1.tex` is selected) is unreachable
from the current selection, so `build_file_rows` marks it `is_unused` and the
template pre-checks its delete checkbox (SUBMISSION-222 auto-check). With
JavaScript, the live recompute (SUBMISSION-231) unchecks detected candidates on
load, so JS users are fine. With **JavaScript disabled**, nothing unchecks it:
a submitter who clicks Continue would delete a plausible alternative "main" (and
its subtree) they never touched -- and the server delete guard only protects the
*selected* top-level plus its reachable files, so an unselected candidate isn't
covered.

**Fix**
`build_file_rows` now takes the set of preflight-detected top-level files
(`toplevel_candidates`). For an unselected detected candidate it clears
`is_unused`, so the template renders it "Not used" but **unchecked**. It stays
deletable (not protected) -- the submitter can still opt in -- it just isn't
pre-selected. The review controller passes `detected_toplevel_files` through.
This makes the server render match the client-side recompute, closing the no-JS
gap.

Deletion semantics are unchanged for everything else; omitting the new argument
preserves the previous behavior for existing callers.

**Tests**
`test_file_context.py`: an unselected detected candidate is not auto-checked
(`is_unused` cleared) and stays deletable, while a plain unused non-candidate is
still auto-checked; omitting `toplevel_candidates` keeps the pre-244 behavior.
