### PR TITLE
SUBMISSION-245: Resync directory delete checkboxes after live top-level recompute

### DIFF
--- a/submit_ce/ui/static/js/review_delete_cascade.js
+++ b/submit_ce/ui/static/js/review_delete_cascade.js
@@ -67,6 +67,12 @@
 
   function refresh() { syncDirStates(); syncDeletionTints(); }
 
+  // Exposed so the live top-level recompute (review_used_recompute.js) can
+  // resync folder tri-states after it sets file checkboxes programmatically --
+  // programmatic `.checked` fires no `change` event, so the listeners below
+  // wouldn't otherwise run (SUBMISSION-245).
+  window.reviewDeleteCascadeRefresh = refresh;
+
   window.addEventListener("DOMContentLoaded", function () {
     dirCheckboxes().forEach(function (dir) {
       dir.addEventListener("change", function () {

--- a/submit_ce/ui/static/js/review_used_recompute.js
+++ b/submit_ce/ui/static/js/review_used_recompute.js
@@ -139,6 +139,12 @@
       setNote(cb, s.note);
       setTint(cb);
     });
+    // We set `.checked` programmatically above, which fires no `change` event,
+    // so the delete-cascade's folder tri-states won't resync on their own.
+    // Nudge it directly (SUBMISSION-245). Guarded in case that script is absent.
+    if (typeof window !== "undefined" && window.reviewDeleteCascadeRefresh) {
+      window.reviewDeleteCascadeRefresh();
+    }
   }
 
   if (typeof window !== "undefined") { window.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
Small follow-up to SUBMISSION-231 / SUBMISSION-228.

**Problem**
When the submitter changes the top-level TeX selection, `review_used_recompute.js`
(SUBMISSION-231) re-labels files and sets their delete checkboxes'
`.checked` **programmatically**. Programmatic `.checked` fires no `change` event,
so the delete-cascade (SUBMISSION-223/228) never resyncs: a directory's
checkbox tri-state (checked / unchecked / indeterminate) can go stale, showing
e.g. an unchecked folder whose children are now all checked. The per-row yellow
tint is already correct (the recompute sets it directly); only the folder-level
checkbox state was left behind.

**Fix**
`review_delete_cascade.js` exposes its existing `refresh()` as
`window.reviewDeleteCascadeRefresh`, and `review_used_recompute.js` calls it at
the end of a recompute (guarded, in case the cascade script isn't present).
Load order already guarantees the cascade script defines the global before the
recompute runs.

Two JS files, no logic changes. Progressive enhancement only; with JavaScript
off, nothing here runs and the server render is unchanged.

**Verify**
Load the two-top-level fixture, switch the selected top-level, and confirm the
folder checkboxes' checked/indeterminate state tracks the files that flipped
used↔not-used (in addition to the row tint, which already worked).
