### PR TITLE
SUBMISSION-246: Build Review Files file list from GCS bucket instead of preflight report

### DIFF
--- a/submit_ce/implementations/compile/directive_manager.py
+++ b/submit_ce/implementations/compile/directive_manager.py
@@ -173,3 +173,34 @@ class DirectiveManager:
             entry['is_oversized'] = img.get('is_oversized', False)
 
         return list(files.values())
+
+    def files_for_review(stored_filenames, preflight_data: dict) -> list:
+        '''Review Files list built from the ACTUAL stored files, annotated with
+        preflight info (SUBMISSION-246).
+
+        Preflight has no contract to enumerate every uploaded file -- for some
+        errors it omits the files it couldn't analyze (e.g. an unsupported
+        ``00README`` format), so a list sourced purely from the preflight report
+        under-counts what's really in the bucket (the D1 bug). The bucket
+        listing (``stored_filenames``) is therefore the authoritative inventory;
+        we overlay the per-file preflight annotations (``used_by*`` edges,
+        ``is_maybe_used``, image size) from ``get_files_from_preflight`` onto it.
+
+        A stored file preflight never mentioned is tagged ``is_unanalyzed`` so
+        the UI can label it "Not analyzed" (rather than silently "Not used" and
+        auto-checking it for deletion). A preflight entry that names a file NOT
+        in the bucket (e.g. a resolved reference to a missing file) is dropped --
+        we can't show or delete a file that isn't stored.
+        '''
+        annotations = {row['filename']: row
+                       for row in DirectiveManager.get_files_from_preflight(preflight_data)}
+        rows = []
+        for filename in stored_filenames:
+            if not filename:
+                continue
+            row = dict(annotations.get(filename, {}))
+            row['filename'] = filename
+            if filename not in annotations:
+                row['is_unanalyzed'] = True
+            rows.append(row)
+        return rows

--- a/submit_ce/implementations/compile/directive_manager.py
+++ b/submit_ce/implementations/compile/directive_manager.py
@@ -175,32 +175,47 @@ class DirectiveManager:
         return list(files.values())
 
     def files_for_review(stored_filenames, preflight_data: dict) -> list:
-        '''Review Files list built from the ACTUAL stored files, annotated with
-        preflight info (SUBMISSION-246).
+        '''Review Files list: the UNION of the actually-stored files (the bucket)
+        and the files preflight reported, annotated with preflight info
+        (SUBMISSION-246).
 
         Preflight has no contract to enumerate every uploaded file -- for some
         errors it omits the files it couldn't analyze (e.g. an unsupported
         ``00README`` format), so a list sourced purely from the preflight report
-        under-counts what's really in the bucket (the D1 bug). The bucket
-        listing (``stored_filenames``) is therefore the authoritative inventory;
-        we overlay the per-file preflight annotations (``used_by*`` edges,
-        ``is_maybe_used``, image size) from ``get_files_from_preflight`` onto it.
+        under-counts what's really in the bucket (the D1 bug). We therefore drive
+        the list from the stored files and overlay the per-file preflight
+        annotations (``used_by*`` edges, ``is_maybe_used``, image size) from
+        ``get_files_from_preflight``.
 
         A stored file preflight never mentioned is tagged ``is_unanalyzed`` so
         the UI can label it "Not analyzed" (rather than silently "Not used" and
-        auto-checking it for deletion). A preflight entry that names a file NOT
-        in the bucket (e.g. a resolved reference to a missing file) is dropped --
-        we can't show or delete a file that isn't stored.
+        auto-checking it for deletion). Files preflight reported that are not in
+        the ``stored_filenames`` listing are still included (annotated) -- this
+        keeps the legacy behavior and makes the list robust if the bucket listing
+        is unavailable or empty.
         '''
         annotations = {row['filename']: row
                        for row in DirectiveManager.get_files_from_preflight(preflight_data)}
         rows = []
-        for filename in stored_filenames:
-            if not filename:
+        seen: set = set()
+        # Stored files (authoritative inventory) first, annotated where preflight
+        # had something to say; bucket-only files are tagged is_unanalyzed.
+        for filename in stored_filenames or []:
+            if not filename or filename in seen:
                 continue
+            seen.add(filename)
             row = dict(annotations.get(filename, {}))
             row['filename'] = filename
             if filename not in annotations:
                 row['is_unanalyzed'] = True
+            rows.append(row)
+        # Any preflight-reported file not in the bucket listing (e.g. a resolved
+        # reference, or a fallback when the listing is empty): include it too.
+        for filename, ann in annotations.items():
+            if filename in seen:
+                continue
+            seen.add(filename)
+            row = dict(ann)
+            row['filename'] = filename
             rows.append(row)
         return rows

--- a/submit_ce/implementations/tests/test_directive_manager.py
+++ b/submit_ce/implementations/tests/test_directive_manager.py
@@ -191,24 +191,35 @@ def test_reachable_from_uses_used_edges_graph():
     assert set(edges["main1.tex"]) <= reach
 
 
-def test_files_for_review_is_bucket_authoritative():
-    """The Review file list comes from the STORED files (bucket), annotated with
-    preflight info. A stored file preflight never mentioned is tagged
-    is_unanalyzed; a preflight-referenced file NOT stored is dropped
-    (SUBMISSION-246)."""
+def test_files_for_review_unions_bucket_and_preflight():
+    """The Review file list is the union of stored files and preflight-reported
+    files, annotated with preflight info. A stored file preflight never mentioned
+    is tagged is_unanalyzed; a preflight-referenced file not in the bucket is
+    still included (annotated) (SUBMISSION-246)."""
     preflight = {"tex_files": [
-        {"filename": "main.tex", "used_other_files": ["fig.png", "missing.png"]},
+        {"filename": "main.tex", "used_other_files": ["fig.png", "referenced.png"]},
     ]}
     # Bucket has main.tex, fig.png, and a stray file preflight never analyzed.
-    # "missing.png" is referenced by preflight but NOT in the bucket.
+    # "referenced.png" is named by preflight but NOT in the bucket listing.
     stored = ["main.tex", "fig.png", "stray.txt"]
     rows = {r["filename"]: r for r in dm.files_for_review(stored, preflight)}
 
-    assert set(rows) == {"main.tex", "fig.png", "stray.txt"}   # bucket, not preflight
-    assert "missing.png" not in rows                            # phantom ref dropped
+    assert set(rows) == {"main.tex", "fig.png", "stray.txt", "referenced.png"}
     assert rows["fig.png"].get("used_by") == ["main.tex"]       # annotation carried
     assert not rows["fig.png"].get("is_unanalyzed")
-    assert rows["stray.txt"].get("is_unanalyzed") is True       # no preflight entry
+    assert rows["stray.txt"].get("is_unanalyzed") is True       # stored, no preflight entry
+    assert not rows["referenced.png"].get("is_unanalyzed")      # preflight-known, included
+
+
+def test_files_for_review_empty_bucket_falls_back_to_preflight():
+    """If the bucket listing is empty, the list still shows the preflight-reported
+    files (none tagged unanalyzed) -- resilience, and what the controller tests
+    that mock preflight rely on."""
+    preflight = {"tex_files": [{"filename": "main.tex"}],
+                 "image_files": [{"filename": "fig.png"}]}
+    rows = {r["filename"]: r for r in dm.files_for_review([], preflight)}
+    assert set(rows) == {"main.tex", "fig.png"}
+    assert not any(r.get("is_unanalyzed") for r in rows.values())
 
 
 def test_files_for_review_d1_regression_unsupported_readme():

--- a/submit_ce/implementations/tests/test_directive_manager.py
+++ b/submit_ce/implementations/tests/test_directive_manager.py
@@ -191,6 +191,38 @@ def test_reachable_from_uses_used_edges_graph():
     assert set(edges["main1.tex"]) <= reach
 
 
+def test_files_for_review_is_bucket_authoritative():
+    """The Review file list comes from the STORED files (bucket), annotated with
+    preflight info. A stored file preflight never mentioned is tagged
+    is_unanalyzed; a preflight-referenced file NOT stored is dropped
+    (SUBMISSION-246)."""
+    preflight = {"tex_files": [
+        {"filename": "main.tex", "used_other_files": ["fig.png", "missing.png"]},
+    ]}
+    # Bucket has main.tex, fig.png, and a stray file preflight never analyzed.
+    # "missing.png" is referenced by preflight but NOT in the bucket.
+    stored = ["main.tex", "fig.png", "stray.txt"]
+    rows = {r["filename"]: r for r in dm.files_for_review(stored, preflight)}
+
+    assert set(rows) == {"main.tex", "fig.png", "stray.txt"}   # bucket, not preflight
+    assert "missing.png" not in rows                            # phantom ref dropped
+    assert rows["fig.png"].get("used_by") == ["main.tex"]       # annotation carried
+    assert not rows["fig.png"].get("is_unanalyzed")
+    assert rows["stray.txt"].get("is_unanalyzed") is True       # no preflight entry
+
+
+def test_files_for_review_d1_regression_unsupported_readme():
+    """D1: preflight omits files it can't analyze (e.g. an unsupported 00README
+    format), so a report-sourced list under-counts. Bucket-sourced list shows
+    all three; the offending 00README.yaml is visible (SUBMISSION-246)."""
+    preflight = {"tex_files": [{"filename": "main.tex"}]}   # only main.tex analyzed
+    stored = ["main.tex", "00README.yaml", "notes.txt"]
+    rows = {r["filename"]: r for r in dm.files_for_review(stored, preflight)}
+    assert set(rows) == {"main.tex", "00README.yaml", "notes.txt"}
+    assert rows["00README.yaml"]["is_unanalyzed"] is True
+    assert rows["notes.txt"]["is_unanalyzed"] is True
+
+
 def test_get_files_from_preflight_tags_maybe_used():
     """Files from the maybe_used_files section are tagged is_maybe_used so the UI
     can tell them apart from truly-unused files (SUBMISSION-221 / C3.2a)."""

--- a/submit_ce/ui/controllers/new/review.py
+++ b/submit_ce/ui/controllers/new/review.py
@@ -161,7 +161,7 @@ def review_files(method: str, params: MultiDict, session: Session,
         'selected_top_level_files': [],
         'top_level_candidates': [],
         'file_issues': {},
-        'recompute': {'edges': {}, 'candidates': [], 'maybe_used': []},
+        'recompute': {'edges': {}, 'candidates': [], 'maybe_used': [], 'unanalyzed': []},
     }
 
     if not workspace:
@@ -292,8 +292,14 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     detected_toplevels = [t.get('filename') for t
                           in (preflight_data.get('detected_toplevel_files') or [])
                           if t.get('filename')]
+    # SUBMISSION-246: enumerate the file list from the ACTUAL stored files (the
+    # bucket) and annotate with preflight info, rather than sourcing it from the
+    # preflight report -- preflight has no contract to list files it couldn't
+    # analyze, so a report-sourced list under-counts what's really uploaded.
+    # Stored files with no preflight annotation are tagged is_unanalyzed.
+    stored_filenames = [f.path for f in (rdata['workspace'].files or [])]
     rdata['file_notes'] = build_file_rows(
-        dm.get_files_from_preflight(preflight_data),
+        dm.files_for_review(stored_filenames, preflight_data),
         file_issues,
         selected_top_level_files,
         used_filenames,
@@ -301,14 +307,17 @@ def _render_review_page(rdata, form, submission_id, preflight_data,
     )
     # SUBMISSION-231 (part 2): data for the client-side live recompute. The same
     # resolved-edge graph the server walked (used_edges), plus the detected
-    # top-level candidates and the coarse maybe-used set, so review_used_recompute.js
-    # can re-root used/unused in the browser as the top-level selection changes --
-    # display only, persisting/deleting nothing until Continue. Candidates are
-    # never auto-checked for deletion (a file the submitter might pick next).
+    # top-level candidates, the coarse maybe-used set, and the unanalyzed files
+    # (SUBMISSION-246), so review_used_recompute.js can re-root used/unused in
+    # the browser as the top-level selection changes -- display only, persisting
+    # /deleting nothing until Continue. Candidates and unanalyzed files are never
+    # auto-checked for deletion.
     rdata['recompute'] = {
         'edges': dm.used_edges(preflight_data),
         'candidates': detected_toplevels,
         'maybe_used': [f for f in (preflight_data.get('maybe_used_files') or []) if f],
+        'unanalyzed': [r['filename'] for r in rdata['file_notes']
+                       if r.get('is_unanalyzed')],
     }
     rdata['has_blocking_issues'] = any(
         n.get('severity') == 'danger' for n in issue_notifications)

--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -51,6 +51,9 @@ def build_file_rows(
       Auto-checked for deletion by the template -- EXCEPT for an unselected
       detected top-level candidate (see ``toplevel_candidates``), which is left
       unchecked;
+    * ``is_unanalyzed`` -- a stored file the preflight report never mentioned
+      (SUBMISSION-246). Rendered "Not analyzed"; not auto-checked for deletion
+      but still deletable. Mutually exclusive with used/maybe/unused;
     * ``is_protected`` -- must not be deleted here (readme, selected top-level, or
       confidently-used); drives the disabled delete checkbox.
 
@@ -97,6 +100,11 @@ def build_file_rows(
         # by any tex file" signal (the used_by* reverse edges) -- the pre-231
         # behavior, preserved so existing callers/tests are unaffected.
         raw_maybe_used = bool(row.get("is_maybe_used"))
+        # A file the preflight report never mentioned (SUBMISSION-246): the
+        # bucket listing is authoritative, so it's shown, but we can't say
+        # anything about its use. Label it "Not analyzed" and -- like an
+        # unselected top-level candidate -- never auto-check it for deletion.
+        unanalyzed = bool(row.get("is_unanalyzed")) and not row["is_readme"] and not row["is_toplevel"]
         if used_filenames is not None:
             used_refs = filename in used_filenames
         else:
@@ -104,9 +112,10 @@ def build_file_rows(
                              or row.get("used_by_tex")
                              or row.get("used_by_bib"))
         ordinary = not row["is_readme"] and not row["is_toplevel"]
-        row["is_used"] = ordinary and used_refs
-        row["is_maybe_used"] = ordinary and not used_refs and raw_maybe_used
-        row["is_unused"] = ordinary and not used_refs and not raw_maybe_used
+        row["is_unanalyzed"] = unanalyzed
+        row["is_used"] = ordinary and not unanalyzed and used_refs
+        row["is_maybe_used"] = ordinary and not unanalyzed and not used_refs and raw_maybe_used
+        row["is_unused"] = ordinary and not unanalyzed and not used_refs and not raw_maybe_used
         # An unselected detected top-level candidate is a plausible alternative
         # "main" the submitter may pick next -- never auto-check it for deletion,
         # even when unreferenced. Clear is_unused so the template renders it

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -158,6 +158,27 @@ def test_toplevel_candidates_omitted_keeps_auto_check():
     assert by["main2.tex"]["is_unused"] is True
 
 
+def test_unanalyzed_file_labeled_not_auto_checked():
+    """A stored file preflight never analyzed (is_unanalyzed) renders "Not
+    analyzed": not is_used/maybe/unused, not auto-checked, still deletable
+    (SUBMISSION-246). The 00README guard still wins over is_unanalyzed."""
+    notes = [
+        {"filename": "main.tex"},                        # top-level
+        {"filename": "stray.txt", "is_unanalyzed": True},  # bucket-only
+        {"filename": "00README.json", "is_unanalyzed": True},  # readme wins
+    ]
+    by = {r["filename"]: r for r in build_file_rows(
+        notes, {}, ["main.tex"], used_filenames=set())}
+
+    s = by["stray.txt"]
+    assert s["is_unanalyzed"] is True
+    assert not (s["is_used"] or s["is_maybe_used"] or s["is_unused"])
+    assert s["is_protected"] is False        # deletable, but template leaves it unchecked
+    # readme classification takes precedence over is_unanalyzed
+    assert by["00README.json"]["is_readme"] is True
+    assert by["00README.json"]["is_unanalyzed"] is False
+
+
 def test_empty_used_filenames_marks_all_ordinary_unused():
     """An empty rooted set (e.g. no top-level yet selected, or nothing reachable)
     is distinct from None: every ordinary file is 'not used' even if it carries

--- a/submit_ce/ui/static/js/review_used_recompute.js
+++ b/submit_ce/ui/static/js/review_used_recompute.js
@@ -93,6 +93,12 @@
       // Selected top-level: what we compile -- not deletable.
       return { disabled: true, checked: false, lock: null, note: "Used: top-level file" };
     }
+    if (sets.unanalyzedSet[fn]) {
+      // Stored in the bucket but absent from the preflight report -- preflight
+      // couldn't analyze it (SUBMISSION-246). Selection-independent: shown,
+      // deletable, but never auto-checked.
+      return { disabled: false, checked: false, lock: null, note: "Not analyzed" };
+    }
     if (sets.used[fn]) {
       // Needed by the current selection: protected from deletion here.
       return { disabled: true, checked: false, lock: "used", note: "Used" };
@@ -117,6 +123,8 @@
     ((data && data.candidates) || []).forEach(function (f) { candidateSet[f] = true; });
     var maybeSet = {};
     ((data && data.maybe_used) || []).forEach(function (f) { maybeSet[f] = true; });
+    var unanalyzedSet = {};
+    ((data && data.unanalyzed) || []).forEach(function (f) { unanalyzedSet[f] = true; });
     var rootSet = {};
     (roots || []).forEach(function (r) { rootSet[r] = true; });
     return {
@@ -124,6 +132,7 @@
       used: reachableFrom(roots, (data && data.edges) || {}),
       candidateSet: candidateSet,
       maybeSet: maybeSet,
+      unanalyzedSet: unanalyzedSet,
     };
   }
 

--- a/submit_ce/ui/static/js/tests/review_used_recompute.test.js
+++ b/submit_ce/ui/static/js/tests/review_used_recompute.test.js
@@ -22,6 +22,7 @@ const DATA = {
   },
   candidates: ["main1.tex", "main2.tex"],
   maybe_used: ["guess.sty"],
+  unanalyzed: ["stray.txt"],
 };
 
 function keys(setObj) { return Object.keys(setObj).sort(); }
@@ -72,5 +73,12 @@ assert.deepStrictEqual(state("chap1.tex", ["main1.tex", "main2.tex"]),
   { disabled: true, checked: false, note: "Used" });
 assert.deepStrictEqual(state("chap2.tex", ["main1.tex", "main2.tex"]),
   { disabled: true, checked: false, note: "Used" });
+
+// unanalyzed file: "Not analyzed", never auto-checked, selection-independent
+// (SUBMISSION-246)
+assert.deepStrictEqual(state("stray.txt", ["main1.tex"]),
+  { disabled: false, checked: false, note: "Not analyzed" });
+assert.deepStrictEqual(state("stray.txt", ["main2.tex"]),
+  { disabled: false, checked: false, note: "Not analyzed" });
 
 console.log("review_used_recompute.test.js: all assertions passed");

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -100,6 +100,11 @@
         {# In preflight's coarse maybe_used_files guess -- kept but no resolved
            reference. Deletable but not suggested (SUBMISSION-221 / C3.2a). #}
         Possibly used
+      {% elif item.is_unanalyzed %}
+        {# Stored in the bucket but absent from the preflight report -- preflight
+           couldn't analyze it (SUBMISSION-246). Shown so the submitter can act
+           on it; not auto-checked for deletion. #}
+        Not analyzed
       {% else %}
         {# Nothing references this file (SUBMISSION-220). #}
         Not used


### PR DESCRIPTION
**Summary**
Build the Review Files file list from the actual stored files (the GCS bucket)
and annotate with preflight info, instead of enumerating it from the preflight
report. Fixes the D1 gap: preflight has no contract to list files it couldn't
analyze, so a report-sourced list under-counts what's really uploaded.

**Problem**
`get_files_from_preflight` reads only preflight's file sections
(`detected_toplevel_files` / `tex_files` / `ancillary_files` / `maybe_used_files`
/ `image_files`). For some errors preflight omits the offending files entirely,
so the Review table showed fewer files than exist in the bucket. Sharp example:
a submission with an unsupported `00README.yaml` -- preflight reports the
`unsupported_zzrm_format` issue (a danger banner) but doesn't list the file, so
the submitter couldn't see or act on the very file causing the block.

**Change**
- New `DirectiveManager.files_for_review(stored_filenames, preflight_data)`: the
  UNION of the stored files (bucket) and the preflight-reported files, with
  preflight rows (`get_files_from_preflight`) overlaid as annotations. A stored
  file with no preflight entry is tagged `is_unanalyzed`; a preflight-reported
  file not in the bucket listing is still included (annotated) -- this preserves
  the legacy behavior and keeps the list robust if the bucket listing is empty
  or unavailable.
- `review.py` enumerates from `workspace.files` (each `FileStatus.path` is the
  source-relative name -- same key space as preflight filenames) and feeds that
  to `build_file_rows`.
- `build_file_rows` handles `is_unanalyzed`: not used/maybe/unused, **not
  auto-checked** for deletion, still deletable. The `00README.json` / selected
  top-level classifications still win over it.
- Template renders "Not analyzed" for these rows.
- Client live recompute (SUBMISSION-231) receives the `unanalyzed` set and
  classifies those files "Not analyzed"/unchecked, selection-independent, so a
  top-level change doesn't re-mark them "Not used"/checked.

`/anc` files: previously listed only if preflight's `ancillary_files` section
named them; now they're enumerated from the bucket like everything else
(`FileStatus.ancillary` still flags them). An `anc/` file preflight didn't list
will now show "Not analyzed" (unchecked) rather than being absent.

**Tests**
- `files_for_review`: bucket + preflight union, annotations carried,
  preflight-only files included, empty-bucket falls back to preflight, plus a D1
  regression (`main.tex` + `00README.yaml` + `notes.txt`, preflight reporting
  only `main.tex` -> all three listed, the readme visible).
- `build_file_rows`: `is_unanalyzed` not auto-checked, deletable; readme wins.
- JS: an unanalyzed file classifies "Not analyzed"/unchecked under either
  selection.

Stacked on SUBMISSION-244 (shares the `build_file_rows` call site).


<img width="1033" height="1252" alt="UploadFiles-Screenshot 2026-08-24 at 3 30 21 PM" src="https://github.com/user-attachments/assets/8d0c6a29-c9cf-47fc-9b63-99e1537f89c6" />

<img width="1035" height="1251" alt="ReviewFiles-2 0-FileListFromGCS-Screenshot 2026-08-24 at 3 31 55 PM" src="https://github.com/user-attachments/assets/4d816ae5-3130-48b9-ad43-40f40230221b" />

