### PR TITLE
SUBMISSION-229: Upload Files: delete a whole directory (all files under it)

### DIFF
--- a/submit_ce/ui/controllers/new/tests/test_upload_delete.py
+++ b/submit_ce/ui/controllers/new/tests/test_upload_delete.py
@@ -1,7 +1,21 @@
-"""Tests for upload_delete controllers (delete_file and delete_all)."""
+"""Tests for upload_delete controllers (delete_file, delete_all, delete_dir)."""
 from http import HTTPStatus as status
+from types import SimpleNamespace
 
 from submit_ce.ui.tests.csrf_util import parse_csrf_token
+
+
+def _ws(mocker, *paths):
+    """A workspace mock whose .files carry the given source-relative paths.
+
+    Files include `bytes` because RemoveFiles.execute evaluates workspace
+    oversize (reads file.bytes) when it runs.
+    """
+    ws = mocker.MagicMock()
+    ws.size = 0
+    ws.files = [SimpleNamespace(path=p, name=p.rsplit('/', 1)[-1], bytes=0)
+                for p in paths]
+    return ws
 
 
 def test_delete_file_get(app, authorized_client, sub_files):
@@ -56,6 +70,62 @@ def test_delete_file_post_confirmed(app, authorized_client, sub_files, mocker):
     mock_store.delete_source_file.assert_called_once_with(
         str(sub.submission_id), 'paper.pdf'
     )
+
+
+def test_delete_dir_get(app, authorized_client, sub_files, mocker):
+    """GET shows the confirmation form listing only the files under the
+    directory prefix (SUBMISSION-229)."""
+    sub = sub_files
+    mock_store = mocker.patch.object(app.api, 'store')
+    mock_store.get_workspace.return_value = _ws(
+        mocker, 'fig/a.png', 'fig/b.png', 'main.tex')
+
+    resp = authorized_client.get(f"/{sub.submission_id}/file_delete_dir",
+                                 query_string={'prefix': 'fig/'})
+    assert resp.status_code == status.OK
+    assert b"Delete Directory" in resp.data
+    assert b"fig/a.png" in resp.data and b"fig/b.png" in resp.data
+    assert b"main.tex" not in resp.data          # outside the directory
+
+
+def test_delete_dir_post_without_confirm(app, authorized_client, sub_files, mocker):
+    """POST without confirmation re-shows the form and deletes nothing."""
+    sub = sub_files
+    url = f"/{sub.submission_id}/file_delete_dir"
+    mock_store = mocker.patch.object(app.api, 'store')
+    mock_store.get_workspace.return_value = _ws(mocker, 'fig/a.png')
+
+    resp = authorized_client.get(url, query_string={'prefix': 'fig/'})
+    csrf = parse_csrf_token(resp)
+    resp = authorized_client.post(url, data={'csrf_token': csrf,
+                                             'dir_prefix': 'fig/'})
+    assert resp.status_code == status.OK
+    mock_store.delete_source_file.assert_not_called()
+
+
+def test_delete_dir_post_confirmed(app, authorized_client, sub_files, mocker):
+    """POST with confirmation deletes exactly the files under the prefix (not
+    siblings) and redirects to file_upload (SUBMISSION-229)."""
+    sub = sub_files
+    url = f"/{sub.submission_id}/file_delete_dir"
+    mock_store = mocker.patch.object(app.api, 'store')
+    mock_store.delete_source_file.return_value.bytes = 1
+    mock_store.get_workspace.return_value = _ws(
+        mocker, 'fig/a.png', 'fig/b.png', 'main.tex')
+
+    resp = authorized_client.get(url, query_string={'prefix': 'fig/'})
+    csrf = parse_csrf_token(resp)
+    resp = authorized_client.post(url, data={
+        'csrf_token': csrf,
+        'dir_prefix': 'fig/',
+        'confirmed': 'true',
+    })
+    assert resp.status_code == status.SEE_OTHER
+    assert resp.headers['Location'] == f"/{sub.submission_id}/file_upload"
+
+    deleted = {c.args[1] for c in mock_store.delete_source_file.call_args_list}
+    assert deleted == {'fig/a.png', 'fig/b.png'}     # only files under fig/
+    assert 'main.tex' not in deleted
 
 
 def test_delete_all_get(app, authorized_client, sub_files):

--- a/submit_ce/ui/controllers/new/upload_delete.py
+++ b/submit_ce/ui/controllers/new/upload_delete.py
@@ -171,10 +171,79 @@ def delete_file(method: str, params: MultiDict, session: Session,
 
 
 
+def _files_under(workspace, prefix: str) -> list[str]:
+    """Paths of every stored file under directory ``prefix`` (normalized to end
+    with '/'). A file belongs to the directory when its path starts with the
+    prefix (SUBMISSION-229)."""
+    p = prefix if prefix.endswith('/') else prefix + '/'
+    files = workspace.files if workspace is not None else []
+    return [f.path for f in files if f.path.startswith(p)]
+
+
+def delete_dir(method: str, params: MultiDict, session: Session,
+               submission_id: str, token: Optional[str] = None,
+               **kwargs) -> Response:
+    """Delete every file under a directory (SUBMISSION-229).
+
+    Directory-scoped counterpart of :func:`delete_file`: reuses the locked
+    ``RemoveFiles`` event with the full list of files under the directory
+    prefix. Like ``delete_file``, deletion only happens on a POST carrying
+    ``confirmed``; a GET only reads the ``prefix`` query param and renders the
+    confirmation form, so a GET can never delete.
+    """
+    submission, _ = get_submission(submission_id)
+    submitter, client = user_and_client_from_session(session)
+    rdata = {'submission': submission, 'submission_id': submission_id}
+    workspace = current_app.api.get_file_store().get_workspace(
+        submission_id=str(submission_id))
+
+    if method == 'GET':
+        # Only read the directory prefix from the GET; never delete on GET.
+        prefix = params['prefix']
+        rdata.update({'form': DeleteDirForm(MultiDict({'dir_prefix': prefix})),
+                      'dir_prefix': prefix,
+                      'dir_files': _files_under(workspace, prefix)})
+        return stay_on_this_stage((rdata, status.OK, {}))
+    elif method == 'POST':
+        form = DeleteDirForm(params)
+        rdata.update({'form': form})
+        if not (form.validate() and form.confirmed.data and form.dir_prefix.data):
+            return stay_on_this_stage((rdata, status.OK, {}))
+
+        targets = _files_under(workspace, form.dir_prefix.data)
+        if not targets:
+            # Nothing under the prefix (already gone / bad prefix): no-op.
+            return return_to_parent_stage((rdata, status.OK, {}))
+
+        command = RemoveFiles(creator=submitter, client=client, files=targets)
+        if validate_command(form, command, submission, 'add_files'):
+            submission, _ = current_app.api.save(command, submission_id=submission.submission_id)
+            workspace = current_app.api.get_file_store().get_workspace(
+                submission_id=str(submission.submission_id))
+            if workspace is not None:
+                inferred = _infer_source_format(workspace.files)
+                if submission.source_format != inferred:
+                    target = inferred.value if inferred is not None else None
+                    current_app.api.save(
+                        SetSourceFormat(creator=submitter, client=client, source_format=target),
+                        submission_id=submission.submission_id,
+                    )
+            return return_to_parent_stage((rdata, status.OK, {}))
+
+    return return_to_parent_stage((rdata, status.BAD_REQUEST, {}))
+
+
 class DeleteFileForm(csrf.CSRFForm):
     """Form for deleting individual files."""
 
     file_path = HiddenField('File', validators=[DataRequired()])
+    confirmed = BooleanField('Confirmed', validators=[DataRequired()])
+
+
+class DeleteDirForm(csrf.CSRFForm):
+    """Form for deleting all files under a directory (SUBMISSION-229)."""
+
+    dir_prefix = HiddenField('Directory', validators=[DataRequired()])
     confirmed = BooleanField('Confirmed', validators=[DataRequired()])
 
 

--- a/submit_ce/ui/routes/ui.py
+++ b/submit_ce/ui/routes/ui.py
@@ -48,6 +48,7 @@ def redirect_to_login(*args, **kwargs) -> Response:
 
 _SUB_ROUTE_PARENT_STAGE = {
     'file_delete': 'file_upload',
+    'file_delete_dir': 'file_upload',
     'file_delete_all': 'file_upload',
 }
 """Auxiliary routes that don't have their own workflow stage but live under one.
@@ -380,6 +381,18 @@ def file_delete(submission_id: str) -> Response:
     """Provide the file deletion endpoint, part of the upload step."""
     return handle(upload_delete.delete_file, 'submit/confirm_delete.html',
                   'Delete File', submission_id, get_params=True,
+                  token=request.environ['token'], flow_controlled=True)
+
+
+@UI.route('/<submission_id>/file_delete_dir', methods=["GET", "POST"])
+@scoped(scopes.EDIT_SUBMISSION, authorizer=is_owner,
+                        unauthorized=redirect_to_login)
+@flow_control(FileUpload)
+def file_delete_dir(submission_id: str) -> Response:
+    """Delete every file under a directory, part of the upload step
+    (SUBMISSION-229)."""
+    return handle(upload_delete.delete_dir, 'submit/confirm_delete_dir.html',
+                  'Delete Directory', submission_id, get_params=True,
                   token=request.environ['token'], flow_controlled=True)
 
 

--- a/submit_ce/ui/static/css/submit.css
+++ b/submit_ce/ui/static/css/submit.css
@@ -291,11 +291,24 @@ ol.file-tree {
     padding: 0; }
     ol.file-tree .column .columns {
       margin: 0; }
+  /* Pin the delete (trash) column to a fixed width and right-align its icon so
+     every trashcan lands at the same offset regardless of the row's zebra /
+     updated highlighting or how deeply the directory is nested
+     (SUBMISSION-229). Applies uniformly to file and directory rows. */
+  ol.file-tree .column.is-narrow {
+    flex: none;
+    width: 2.5rem;
+    text-align: right; }
   ol.file-tree > li ol {
     border-left: 2px solid #CCC;
     margin: 0 0 0 1rem; }
     ol.file-tree > li ol li {
-      padding-left: 1em; }
+      padding-left: 1em;
+      /* Indentation belongs on the left only. The base li padding-right (.25em)
+         otherwise accumulates one level per nesting depth, creeping each deeper
+         row's right edge -- and its delete icon -- leftward. Zero it on nested
+         rows so every trashcan lines up in the same column (SUBMISSION-229). */
+      padding-right: 0; }
       ol.file-tree > li ol li:first-child {
         margin-top: 0; }
 

--- a/submit_ce/ui/templates/submit/confirm_delete_dir.html
+++ b/submit_ce/ui/templates/submit/confirm_delete_dir.html
@@ -1,0 +1,33 @@
+{% extends "submit/base.html" %}
+
+{% import "submit/submit_macros.html" as submit_macros %}
+
+{% block title -%}Delete Directory{%- endblock title %}
+
+{% block within_content %}
+<form method="POST" action="{{ url_for('ui.file_delete_dir', submission_id=submission_id) }}">
+  {{ form.csrf_token }}
+  <div class="container breathe-vertical" style="max-width: 640px">
+    <div class="message is-danger is-inline-block">
+      <div class="message-body">
+        <h3 class="is-size-5 has-text-weight-bold has-text-primary">
+          This action will remove the directory
+          <code>{{ dir_prefix }}</code> and all of its files from arXiv:
+        </h3>
+        <ul>
+          {% for path in dir_files %}
+          <li>{{ path }}</li>
+          {% endfor %}
+        </ul>
+        {{ form.dir_prefix }}
+        {{ form.csrf_token }}
+        <input type="hidden" name="confirmed" value="true" />
+        <div class="buttons is-centered">
+            <a class="button" href="{{ url_for('ui.file_upload', submission_id=submission_id) }}">Keep these files</a>
+            <button class="button is-primary" type="submit">Delete these files</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock within_content %}

--- a/submit_ce/ui/templates/submit/file_upload.html
+++ b/submit_ce/ui/templates/submit/file_upload.html
@@ -34,13 +34,28 @@
        `prefix ~ key ~ '/'` is the directory's full path, threaded through the
        recursion so nested folders get their correct prefix. #}
     {% if key %}
-    {{svg.folder(klass="icon filter-blue")}}
-    <strong>{{ key }}/</strong>
-    <a href="{{ url_for('ui.file_delete_dir', submission_id=submission_id) }}?prefix={{ prefix }}{{ key }}/"
-       aria-label="Delete directory {{ prefix }}{{ key }}/">
-      {{svg.trashcan()}}
-      <span class="is-sr-only">Delete directory</span>
-    </a>{% endif %}
+    {# Same two-column grid as file rows so the directory trashcan lines up in
+       the right-hand delete column; the size/modified cells are empty for a
+       directory (SUBMISSION-229). #}
+    <div class="columns">
+      <div class="column">
+        {{svg.folder(klass="icon filter-blue")}}
+        <strong>{{ key }}/</strong>
+      </div>
+      <div class="column is-one-third-tablet">
+        <div class="columns is-mobile">
+          <div class="column"></div>
+          <div class="column"></div>
+          <div class="column has-text-centered is-narrow">
+            <a href="{{ url_for('ui.file_delete_dir', submission_id=submission_id) }}?prefix={{ prefix }}{{ key }}/"
+               aria-label="Delete directory {{ prefix }}{{ key }}/">
+              {{svg.trashcan()}}
+              <span class="is-sr-only">Delete directory</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>{% endif %}
     <ol class="{% if not key %}file-tree{% endif %}" style="list-style-type: none;">
       {% for k, subitem in item.items() %}
       {{ display_tree(k, subitem, loop.cycle('', 'even'), (prefix ~ key ~ '/') if key else prefix) }}

--- a/submit_ce/ui/templates/submit/file_upload.html
+++ b/submit_ce/ui/templates/submit/file_upload.html
@@ -5,7 +5,7 @@
  <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
 {% endblock addl_head %}
 
-{% macro display_tree(key, item, even) %}
+{% macro display_tree(key, item, even, prefix='') %}
   {% if key %}
   <li class="{% if item.errors %}is-warning{% elif item.modified and item|just_updated %}is-success{% endif %} {% if even %}even{% endif %}">
   {% endif %}
@@ -29,13 +29,21 @@
     </div>
     {% else %}
     {# Directory row (SUBMISSION-227): a folder icon + bold name so the
-       tree reads clearly; children are indented via the nested <ol> below. #}
+       tree reads clearly; children are indented via the nested <ol> below.
+       The trashcan deletes every file under this directory (SUBMISSION-229);
+       `prefix ~ key ~ '/'` is the directory's full path, threaded through the
+       recursion so nested folders get their correct prefix. #}
     {% if key %}
     {{svg.folder(klass="icon filter-blue")}}
-    <strong>{{ key }}/</strong>{% endif %}
+    <strong>{{ key }}/</strong>
+    <a href="{{ url_for('ui.file_delete_dir', submission_id=submission_id) }}?prefix={{ prefix }}{{ key }}/"
+       aria-label="Delete directory {{ prefix }}{{ key }}/">
+      {{svg.trashcan()}}
+      <span class="is-sr-only">Delete directory</span>
+    </a>{% endif %}
     <ol class="{% if not key %}file-tree{% endif %}" style="list-style-type: none;">
       {% for k, subitem in item.items() %}
-      {{ display_tree(k, subitem, loop.cycle('', 'even')) }}
+      {{ display_tree(k, subitem, loop.cycle('', 'even'), (prefix ~ key ~ '/') if key else prefix) }}
       {% endfor %}
     </ol>
     {% endif %}


### PR DESCRIPTION
**Summary**
Add "delete a whole directory" to the Upload Files page (SUBMISSION-229 / G33).
Submit 1.5 has a folder-row trash; 2.0's Upload page could only delete files one
at a time. (The Review page already got directory delete via the 223 cascade;
this brings the Upload page to parity.)

**Change**
- `file_upload.html`: the recursive `display_tree` macro now threads a `prefix`
  (the directory's full path) through the recursion, and directory rows carry a
  trashcan linking to `file_delete_dir?prefix=<full/path>/`. Files keep their
  per-file trashcan.
- `upload_delete.delete_dir` + `DeleteDirForm`: gathers every stored file under
  the prefix and dispatches the existing locked `RemoveFiles(files=[...])`
  event -- no new deletion mechanism. Mirrors `delete_file`'s confirm flow: a
  GET only reads the `prefix` and renders the confirmation page (so a GET can
  never delete); deletion happens only on a POST carrying `confirmed`. After the
  delete it re-infers `source_format`, same as `delete_file`.
- `routes/ui.py`: registers `/<submission_id>/file_delete_dir` and maps it to
  the `file_upload` parent stage.
- `confirm_delete_dir.html`: confirmation page listing the files to be removed.

**Tests**
- GET renders the confirmation listing only files under the prefix (siblings
  excluded).
- POST without `confirmed` re-shows the form and deletes nothing.
- POST with `confirmed` deletes exactly the files under the prefix (not
  siblings) and redirects to `file_upload`.

Independent of the Review-page work; branched off develop (227's Upload tree is
already there).

Before: Note trash can alignment is already off for right justified trash cans. Fixed in next screenshot.

<img width="1043" height="1251" alt="UploadFiles-2 0-PreChange-Screenshot 2026-08-24 at 5 56 31 PM" src="https://github.com/user-attachments/assets/8c3cbde2-a3bb-4207-9472-473a7185d61a" />

Trash can alignment fixed:

<img width="1390" height="1186" alt="UploadFiles-2 0-RightJustifyDirectoryDeleteIcon-Screenshot 2026-08-27 at 10 57 08 AM" src="https://github.com/user-attachments/assets/a11fa9b3-447f-47c9-8e60-9b04299e79b3" />
