### PR TITLE
SUBMISSION-252: Protect ancillary (anc/) files from deletion and label them

### DIFF
--- a/submit_ce/ui/preflight/file_context.py
+++ b/submit_ce/ui/preflight/file_context.py
@@ -22,6 +22,13 @@ from typing import Any, Dict, List, Optional, Set
 # note rather than a usage line.
 README_FILENAME = "00README.json"
 
+# Source-relative prefix for ancillary files. arXiv stores ancillary data/code
+# under anc/ (matched by preflight's ancillary_files, the store's
+# FileStatus.ancillary, and 1.5's Upload.pm). Files here are supplementary --
+# not compiled -- so they must NOT be classified "unused"/auto-checked for
+# deletion (SUBMISSION-252); they get their own "Ancillary" label.
+ANCILLARY_PREFIX = "anc/"
+
 
 def build_file_rows(
     file_notes: List[Dict[str, Any]],
@@ -51,6 +58,10 @@ def build_file_rows(
       Auto-checked for deletion by the template -- EXCEPT for an unselected
       detected top-level candidate (see ``toplevel_candidates``), which is left
       unchecked;
+    * ``is_ancillary`` -- a file under ``anc/`` (SUBMISSION-252). Rendered
+      "Ancillary"; supplementary, so it is NOT classified used/unused and is
+      never auto-checked for deletion (it stays deletable-but-unchecked, matching
+      1.5). Its own class, mutually exclusive with used/maybe/unused/unanalyzed;
     * ``is_unanalyzed`` -- a stored file the preflight report never mentioned
       (SUBMISSION-246). Rendered "Not analyzed"; not auto-checked for deletion
       but still deletable. Mutually exclusive with used/maybe/unused;
@@ -100,18 +111,28 @@ def build_file_rows(
         # by any tex file" signal (the used_by* reverse edges) -- the pre-231
         # behavior, preserved so existing callers/tests are unaffected.
         raw_maybe_used = bool(row.get("is_maybe_used"))
+        # Ancillary files (anc/) are supplementary, not compiled: they must never
+        # be classified "unused" and auto-checked for deletion -- that would let
+        # a submitter wipe their data/code on Continue. They get a dedicated
+        # "Ancillary" label and stay deletable-but-unchecked (SUBMISSION-252).
+        is_ancillary = bool(filename) and filename.startswith(ANCILLARY_PREFIX)
         # A file the preflight report never mentioned (SUBMISSION-246): the
         # bucket listing is authoritative, so it's shown, but we can't say
         # anything about its use. Label it "Not analyzed" and -- like an
         # unselected top-level candidate -- never auto-check it for deletion.
-        unanalyzed = bool(row.get("is_unanalyzed")) and not row["is_readme"] and not row["is_toplevel"]
+        unanalyzed = (bool(row.get("is_unanalyzed")) and not row["is_readme"]
+                      and not row["is_toplevel"] and not is_ancillary)
         if used_filenames is not None:
             used_refs = filename in used_filenames
         else:
             used_refs = bool(row.get("used_by")
                              or row.get("used_by_tex")
                              or row.get("used_by_bib"))
-        ordinary = not row["is_readme"] and not row["is_toplevel"]
+        # Ancillary, like the 00README and a selected top-level, is its own class
+        # and is none of used/maybe/unused/unanalyzed.
+        ordinary = (not row["is_readme"] and not row["is_toplevel"]
+                    and not is_ancillary)
+        row["is_ancillary"] = is_ancillary
         row["is_unanalyzed"] = unanalyzed
         row["is_used"] = ordinary and not unanalyzed and used_refs
         row["is_maybe_used"] = ordinary and not unanalyzed and not used_refs and raw_maybe_used

--- a/submit_ce/ui/preflight/tests/test_file_context.py
+++ b/submit_ce/ui/preflight/tests/test_file_context.py
@@ -158,6 +158,29 @@ def test_toplevel_candidates_omitted_keeps_auto_check():
     assert by["main2.tex"]["is_unused"] is True
 
 
+def test_ancillary_files_labeled_and_not_auto_checked():
+    """Files under anc/ are ancillary: labeled, never classified used/unused, and
+    NOT auto-checked for deletion (they must not be swept away on Continue).
+    Deletable-but-unchecked, matching 1.5 (SUBMISSION-252)."""
+    notes = [
+        {"filename": "main.tex"},                       # selected top-level
+        {"filename": "anc/readme.txt"},                 # ancillary depth 1
+        {"filename": "anc/code/lib/helper.py"},         # ancillary depth 3
+        {"filename": "orphan.png"},                     # genuinely unused
+    ]
+    by = {r["filename"]: r for r in build_file_rows(
+        notes, {}, ["main.tex"], used_filenames=set())}
+
+    for anc in ("anc/readme.txt", "anc/code/lib/helper.py"):
+        r = by[anc]
+        assert r["is_ancillary"] is True
+        assert not (r["is_used"] or r["is_maybe_used"]
+                    or r["is_unused"] or r.get("is_unanalyzed"))
+        assert r["is_protected"] is False        # deletable, but template leaves unchecked
+    # a real unused file is still auto-checked (is_unused) -- ancillary is the exception
+    assert by["orphan.png"]["is_unused"] is True
+
+
 def test_unanalyzed_file_labeled_not_auto_checked():
     """A stored file preflight never analyzed (is_unanalyzed) renders "Not
     analyzed": not is_used/maybe/unused, not auto-checked, still deletable

--- a/submit_ce/ui/static/js/review_used_recompute.js
+++ b/submit_ce/ui/static/js/review_used_recompute.js
@@ -93,6 +93,13 @@
       // Selected top-level: what we compile -- not deletable.
       return { disabled: true, checked: false, lock: null, note: "Used: top-level file" };
     }
+    if (fn && fn.indexOf("anc/") === 0) {
+      // Ancillary file (under anc/) -- supplementary, selection-independent.
+      // Never auto-checked for deletion; labeled. Mirrors build_file_rows
+      // (SUBMISSION-252). Kept out of the used/unused reclassification so the
+      // live recompute can't re-check it.
+      return { disabled: false, checked: false, lock: null, note: "Ancillary" };
+    }
     if (sets.unanalyzedSet[fn]) {
       // Stored in the bucket but absent from the preflight report -- preflight
       // couldn't analyze it (SUBMISSION-246). Selection-independent: shown,

--- a/submit_ce/ui/static/js/tests/review_used_recompute.test.js
+++ b/submit_ce/ui/static/js/tests/review_used_recompute.test.js
@@ -81,4 +81,11 @@ assert.deepStrictEqual(state("stray.txt", ["main1.tex"]),
 assert.deepStrictEqual(state("stray.txt", ["main2.tex"]),
   { disabled: false, checked: false, note: "Not analyzed" });
 
+// ancillary (anc/) file: "Ancillary", never auto-checked, path-based &
+// selection-independent (SUBMISSION-252)
+assert.deepStrictEqual(state("anc/readme.txt", ["main1.tex"]),
+  { disabled: false, checked: false, note: "Ancillary" });
+assert.deepStrictEqual(state("anc/code/lib/helper.py", ["main2.tex"]),
+  { disabled: false, checked: false, note: "Ancillary" });
+
 console.log("review_used_recompute.test.js: all assertions passed");

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -96,6 +96,10 @@
         {% if item.used_by_tex %}Used by (TeX): {{ item.used_by_tex | join(', ') }}<br>{% endif %}
         {% if item.used_by_bib %}Used by (bib): {{ item.used_by_bib | join(', ') }}{% endif %}
         {% if not (item.used_by or item.used_by_tex or item.used_by_bib) %}Used{% endif %}
+      {% elif item.is_ancillary %}
+        {# A file under anc/ -- supplementary data/code, not compiled. Labeled
+           and never auto-checked for deletion (SUBMISSION-252). #}
+        Ancillary
       {% elif item.is_maybe_used %}
         {# In preflight's coarse maybe_used_files guess -- kept but no resolved
            reference. Deletable but not suggested (SUBMISSION-221 / C3.2a). #}
@@ -125,11 +129,13 @@
              aria-label="Select all deletable files in {{ prefix }}{{ key }}/ for deletion">
     </td>
     {# Folder icon + bold name, indented by depth, matching the Upload page
-       (SUBMISSION-228); the Notes column labels it a Directory. #}
+       (SUBMISSION-228). A directory under anc/ is labeled "Ancillary directory"
+       so the ancillary cue carries to the folders too (SUBMISSION-252), rather
+       than a bare "Directory" -- but not "Ancillary file", since it's a dir. #}
     <td style="padding-left: {{ prefix.count('/') * 1.5 + 0.5 }}rem">
       {{ svg.folder(klass="icon filter-blue") }} <strong>{{ key }}/</strong>
     </td>
-    <td>Directory</td>
+    <td>{% if (prefix ~ key ~ '/').startswith('anc/') %}Ancillary directory{% else %}Directory{% endif %}</td>
   </tr>
   {% for k, subitem in item.items() %}
     {{ display_preflight_tree(k, subitem, prefix ~ key ~ '/') }}


### PR DESCRIPTION
Summary:
Submit 2.0 currently marks ancillary files for deletion (bug).

Details:
anc/ files has no references (in preflight), so build_file_rows classified them is_unused -> auto-checked for deletion (222); a submitter could wipe ancillary data/code on Continue. Recognize anc/ files (path prefix; matches preflight ancillary_files, FileStatus.ancillary, and 1.5): label 'Ancillary', keep out of used/unused, never auto-check; still deletable-but-unchecked, matching 1.5. Mirrored in the live recompute JS. Tests + fixture 29_ancillary_files.

Review Files page with Ancillary files correctly protected and labeled.

<img width="852" height="426" alt="ReviewFiles-2 0-AncillaryUpdate-Screenshot 2026-08-27 at 4 00 07 PM" src="https://github.com/user-attachments/assets/6c13b93b-967d-4e18-8425-07262b6ae8bd" />
