### PR TITLE
SUBMISSION-251: Hide the unimplemented Ancillary checkbox on Upload Files

### DIFF
--- a/submit_ce/ui/templates/submit/file_upload.html
+++ b/submit_ce/ui/templates/submit/file_upload.html
@@ -174,6 +174,12 @@
             </label>
           </div>
         </div>
+        {# Ancillary checkbox hidden until it's actually wired up
+           (SUBMISSION-251). The control is a no-op today -- checking it does not
+           place uploads under anc/ -- and its help text promises behavior that
+           doesn't happen yet, so we hide it rather than mislead submitters.
+           Restore when the deposit-to-anc/ behavior lands (SUBMISSION-250). #}
+        {#
         <div class="control" style="margin-top: .35em">
           <label class="checkbox">
             {{ form.ancillary }} Ancillary
@@ -184,6 +190,7 @@
             </a>
           </label>
         </div>
+        #}
         <div class="control">
           <button id="file-submit" type="submit" class="button is-link" disabled>Upload</button>
         </div>


### PR DESCRIPTION
Summary:

The Ancillary checkbox is a no-op (upload.py TODO: not handled) and its help text promises behavior that doesn't happen (files placed under anc/). Hide it so submitters aren't misled; the form field is left in place (defaults False). Restore when the deposit-to-anc/ behavior is implemented (SUBMISSION-250). Template-only.

No more Ancillary checkbox:

<img width="885" height="142" alt="UploadFiles-2 0-HideAncillaryCheckbox-Screenshot 2026-08-27 at 4 10 02 PM" src="https://github.com/user-attachments/assets/0887b774-8c01-418a-9959-7c15947ae0c6" />
