### PR TITLE
SUBMISSION-253: Add delete confirmation modal to Review Files page

### DIFF
--- a/submit_ce/ui/static/js/review_delete_confirm.js
+++ b/submit_ce/ui/static/js/review_delete_confirm.js
@@ -1,0 +1,107 @@
+// review_delete_confirm.js  (SUBMISSION-253)
+//
+// Progressive enhancement for the Review Files page: a confirmation dialog on
+// Continue, mirroring Submit 1.5's confirm-on-delete. The Review page deletes
+// every checked file when the user continues (including the unused files it
+// auto-checks, SUBMISSION-222), invalidating preflight and routing back to
+// Upload. That is destructive and, unlike the Upload page's per-file/dir
+// deletes, previously had no confirmation. This intercepts Continue when any
+// deletable files are checked, lists them, and only submits on confirm.
+//
+// With JavaScript off, the modal never appears and Continue behaves exactly as
+// before -- the no-JS path is unchanged.
+(function () {
+  "use strict";
+
+  // Files marked for deletion: checked, submittable per-file checkboxes. The
+  // folder cascade checkbox has no `name`, so it is naturally excluded.
+  function deletions() {
+    return Array.prototype.slice.call(
+      document.querySelectorAll('input[name="selected_files"]:checked')
+    );
+  }
+
+  window.addEventListener("DOMContentLoaded", function () {
+    var overlay = document.getElementById("review-delete-overlay");
+    var dialog = document.getElementById("review-delete-dialog");
+    var listEl = document.getElementById("review-delete-list");
+    var countEl = document.getElementById("review-delete-count");
+    var cancelBtn = document.getElementById("review-delete-cancel");
+    var proceedBtn = document.getElementById("review-delete-proceed");
+    var closeBtn = document.getElementById("review-delete-close");
+    var form = document.getElementById("form");
+
+    // If the modal partial isn't on the page, leave native behavior in place.
+    if (!overlay || !dialog || !proceedBtn || !form) { return; }
+
+    var pendingButton = null;  // the Continue button we intercepted
+    var lastFocus = null;
+
+    function openModal(files, button) {
+      pendingButton = button;
+      lastFocus = document.activeElement;
+      listEl.innerHTML = "";
+      files.forEach(function (cb) {
+        var li = document.createElement("li");
+        li.textContent = cb.value;
+        listEl.appendChild(li);
+      });
+      countEl.textContent = "By continuing the following " + files.length +
+        (files.length === 1 ? " file will be deleted:" : " files will be deleted:");
+      overlay.hidden = false;
+      dialog.focus();
+      document.addEventListener("keydown", onKeydown);
+    }
+
+    function closeModal() {
+      overlay.hidden = true;
+      pendingButton = null;
+      document.removeEventListener("keydown", onKeydown);
+      if (lastFocus) { lastFocus.focus(); }
+    }
+
+    function onKeydown(e) {
+      if (e.key === "Escape") { closeModal(); }
+    }
+
+    // Intercept only the "Continue" (next) action, and only when files are
+    // actually marked for deletion. Go Back and other actions are untouched;
+    // continuing with nothing checked proceeds straight through.
+    document.querySelectorAll('button[name="action"][value="next"]').forEach(
+      function (btn) {
+        btn.addEventListener("click", function (e) {
+          var files = deletions();
+          if (files.length === 0) { return; }  // nothing to confirm
+          e.preventDefault();
+          openModal(files, btn);
+        });
+      }
+    );
+
+    proceedBtn.addEventListener("click", function () {
+      var btn = pendingButton;
+      closeModal();
+      // Submit as if the intercepted Continue button was the submitter so its
+      // name/value (action=next) is included -- form.submit()/requestSubmit()
+      // with no submitter would drop it, and the controller keys off action.
+      if (form.requestSubmit && btn) {
+        form.requestSubmit(btn);
+      } else {
+        if (btn && btn.name) {
+          var hidden = document.createElement("input");
+          hidden.type = "hidden";
+          hidden.name = btn.name;
+          hidden.value = btn.value;
+          form.appendChild(hidden);
+        }
+        form.submit();
+      }
+    });
+
+    cancelBtn.addEventListener("click", closeModal);
+    if (closeBtn) { closeBtn.addEventListener("click", closeModal); }
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) { closeModal(); }
+    });
+  });
+})();

--- a/submit_ce/ui/static/js/tests/review_delete_confirm.test.js
+++ b/submit_ce/ui/static/js/tests/review_delete_confirm.test.js
@@ -1,0 +1,209 @@
+// Node test for review_delete_confirm.js (SUBMISSION-253).
+// No DOM library / test runner needed -- run with:
+//   node review_delete_confirm.test.js
+// Exits non-zero on failure.
+//
+// The source file is DOM-driven (it wires a confirmation modal to the Review
+// Files Continue button), so this provides a minimal hand-rolled DOM stub --
+// just enough of document/window for the file's selectors and event wiring --
+// and drives it through the three behaviors that matter:
+//   1. Continue with files checked  -> intercepted, modal opens listing them.
+//   2. Proceed                      -> submits via requestSubmit(button) so the
+//                                       action=next value is preserved.
+//   3. Continue with nothing checked -> NOT intercepted (native submit).
+// Plus Cancel/Escape closing without submitting.
+
+const assert = require("assert");
+
+// --- minimal DOM stub -------------------------------------------------------
+
+function makeEl(props) {
+  const listeners = {};
+  const el = Object.assign({
+    tagName: "DIV",
+    children: [],
+    hidden: false,
+    textContent: "",
+    _innerHTML: "",
+    disabled: false,
+    checked: false,
+    name: "",
+    value: "",
+    attrs: {},
+    classList: { contains: function () { return false; } },
+    addEventListener: function (type, fn) {
+      (listeners[type] = listeners[type] || []).push(fn);
+    },
+    dispatch: function (type, evt) {
+      evt = evt || {};
+      evt.type = type;
+      evt.target = evt.target || el;
+      (listeners[type] || []).forEach(function (fn) { fn(evt); });
+    },
+    appendChild: function (child) { el.children.push(child); },
+    focus: function () {},
+  }, props || {});
+  Object.defineProperty(el, "innerHTML", {
+    get: function () { return el._innerHTML; },
+    set: function (v) { el._innerHTML = v; if (v === "") { el.children = []; } },
+  });
+  return el;
+}
+
+function buildDom(checkedFiles) {
+  const overlay = makeEl({ id: "review-delete-overlay", hidden: true });
+  const dialog = makeEl({ id: "review-delete-dialog" });
+  const list = makeEl({ id: "review-delete-list" });
+  const count = makeEl({ id: "review-delete-count" });
+  const cancel = makeEl({ id: "review-delete-cancel" });
+  const proceed = makeEl({ id: "review-delete-proceed" });
+
+  let requestSubmitArg = "UNSET";
+  const form = makeEl({
+    id: "form",
+    requestSubmit: function (submitter) { requestSubmitArg = submitter; },
+    submit: function () { requestSubmitArg = "form.submit"; },
+  });
+
+  const continueBtn = makeEl({
+    tagName: "BUTTON", name: "action", value: "next",
+    attrs: { name: "action", value: "next" },
+  });
+
+  // checkedFiles: array of {value, checked}
+  const fileEls = checkedFiles.map(function (f) {
+    return makeEl({
+      tagName: "INPUT", name: "selected_files",
+      value: f.value, checked: f.checked, disabled: false,
+    });
+  });
+
+  const byId = {
+    "review-delete-overlay": overlay,
+    "review-delete-dialog": dialog,
+    "review-delete-list": list,
+    "review-delete-count": count,
+    "review-delete-cancel": cancel,
+    "review-delete-proceed": proceed,
+    "form": form,
+  };
+
+  const windowListeners = {};
+  const documentListeners = {};
+
+  global.document = {
+    getElementById: function (id) { return byId[id] || null; },
+    createElement: function (tag) { return makeEl({ tagName: tag.toUpperCase() }); },
+    querySelectorAll: function (sel) {
+      if (sel === 'input[name="selected_files"]:checked') {
+        return fileEls.filter(function (e) { return e.checked; });
+      }
+      if (sel === 'button[name="action"][value="next"]') {
+        return [continueBtn];
+      }
+      return [];
+    },
+    addEventListener: function (t, fn) {
+      (documentListeners[t] = documentListeners[t] || []).push(fn);
+    },
+    removeEventListener: function (t, fn) {
+      documentListeners[t] = (documentListeners[t] || [])
+        .filter(function (f) { return f !== fn; });
+    },
+    dispatchDocument: function (type, evt) {
+      evt = evt || {}; evt.type = type;
+      (documentListeners[type] || []).slice().forEach(function (fn) { fn(evt); });
+    },
+    activeElement: makeEl({}),
+  };
+
+  global.window = {
+    addEventListener: function (t, fn) {
+      (windowListeners[t] = windowListeners[t] || []).push(fn);
+    },
+    fire: function (type) { (windowListeners[type] || []).forEach(function (fn) { fn(); }); },
+  };
+
+  return {
+    overlay: overlay, list: list, count: count,
+    cancel: cancel, proceed: proceed, form: form, continueBtn: continueBtn,
+    ready: function () { global.window.fire("DOMContentLoaded"); },
+    requestSubmitArg: function () { return requestSubmitArg; },
+    escape: function () { global.document.dispatchDocument("keydown", { key: "Escape" }); },
+  };
+}
+
+function loadFresh() {
+  delete require.cache[require.resolve("../review_delete_confirm.js")];
+  require("../review_delete_confirm.js");
+}
+
+// --- 1. Continue with files checked -> intercept + open modal ---------------
+{
+  const dom = buildDom([{ value: "unused1.tex", checked: true },
+                        { value: "fig/extra.png", checked: true }]);
+  loadFresh();
+  dom.ready();
+
+  let prevented = false;
+  dom.continueBtn.dispatch("click", { preventDefault: function () { prevented = true; } });
+
+  assert.strictEqual(prevented, true, "Continue is intercepted when files are checked");
+  assert.strictEqual(dom.overlay.hidden, false, "modal is shown");
+  assert.strictEqual(dom.list.children.length, 2, "both checked files are listed");
+  assert.deepStrictEqual(dom.list.children.map(function (li) { return li.textContent; }),
+    ["unused1.tex", "fig/extra.png"], "listed values match the checked files");
+  assert.ok(/2 files/.test(dom.count.textContent), "count reflects 2 files");
+  assert.strictEqual(dom.requestSubmitArg(), "UNSET", "nothing submitted yet");
+
+  // Proceed -> submits with the intercepted button as submitter.
+  dom.proceed.dispatch("click");
+  assert.strictEqual(dom.requestSubmitArg(), dom.continueBtn,
+    "proceed submits via requestSubmit(continueButton) so action=next is kept");
+  assert.strictEqual(dom.overlay.hidden, true, "modal closes on proceed");
+}
+
+// --- 2. Cancel closes without submitting ------------------------------------
+{
+  const dom = buildDom([{ value: "unused1.tex", checked: true }]);
+  loadFresh();
+  dom.ready();
+  dom.continueBtn.dispatch("click", { preventDefault: function () {} });
+  assert.strictEqual(dom.overlay.hidden, false);
+  dom.cancel.dispatch("click");
+  assert.strictEqual(dom.overlay.hidden, true, "modal closes on cancel");
+  assert.strictEqual(dom.requestSubmitArg(), "UNSET", "cancel submits nothing");
+}
+
+// --- 3. Escape closes without submitting ------------------------------------
+{
+  const dom = buildDom([{ value: "unused1.tex", checked: true }]);
+  loadFresh();
+  dom.ready();
+  dom.continueBtn.dispatch("click", { preventDefault: function () {} });
+  dom.escape();
+  assert.strictEqual(dom.overlay.hidden, true, "modal closes on Escape");
+  assert.strictEqual(dom.requestSubmitArg(), "UNSET", "escape submits nothing");
+}
+
+// --- 4. Continue with nothing checked -> NOT intercepted (native submit) ----
+{
+  const dom = buildDom([{ value: "unused1.tex", checked: false }]);
+  loadFresh();
+  dom.ready();
+  let prevented = false;
+  dom.continueBtn.dispatch("click", { preventDefault: function () { prevented = true; } });
+  assert.strictEqual(prevented, false, "Continue not intercepted when nothing is checked");
+  assert.strictEqual(dom.overlay.hidden, true, "modal stays hidden");
+}
+
+// --- 5. Count uses singular for exactly one file ----------------------------
+{
+  const dom = buildDom([{ value: "solo.tex", checked: true }]);
+  loadFresh();
+  dom.ready();
+  dom.continueBtn.dispatch("click", { preventDefault: function () {} });
+  assert.ok(/1 file will/.test(dom.count.textContent), "singular phrasing for one file");
+}
+
+console.log("review_delete_confirm.test.js: all assertions passed");

--- a/submit_ce/ui/templates/submit/review_delete_confirm_modal.html
+++ b/submit_ce/ui/templates/submit/review_delete_confirm_modal.html
@@ -1,0 +1,114 @@
+{# SUBMISSION-253: delete-confirmation modal for the Review Files page.
+
+   Progressive enhancement -- review_delete_confirm.js intercepts Continue when
+   any deletable files are checked and shows this dialog listing them. Mirrors
+   Submit 1.5's confirm-on-delete dialog: centered title with a close (x), a
+   centered "By continuing the following N files will be deleted:" lead, a plain
+   bulleted list, and two equal-width Cancel / Confirm buttons. With JavaScript
+   off it stays hidden and Continue behaves as before (no-JS path unchanged). #}
+<div id="review-delete-overlay" role="presentation" hidden>
+  <div id="review-delete-dialog" role="dialog" aria-modal="true"
+       aria-labelledby="review-delete-title"
+       aria-describedby="review-delete-count" tabindex="-1">
+
+    <button type="button" id="review-delete-close"
+            aria-label="Cancel file deletion">&times;</button>
+
+    <h2 id="review-delete-title">Confirm File Deletion</h2>
+
+    <p id="review-delete-count" class="review-delete-count"></p>
+
+    <div class="modal-content">
+      <ul id="review-delete-list" class="review-delete-list"></ul>
+    </div>
+
+    <div class="review-delete-actions">
+      <button type="button" id="review-delete-cancel"
+              class="button review-delete-btn-cancel">
+        Cancel
+      </button>
+      <button type="button" id="review-delete-proceed"
+              class="button review-delete-btn-confirm">
+        Confirm
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+#review-delete-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+#review-delete-overlay[hidden] { display: none; }
+
+#review-delete-dialog {
+  position: relative;
+  background: #fff;
+  width: 90%;
+  max-width: 640px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  border-radius: 6px;
+  padding: 2rem 2.5rem;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+}
+
+#review-delete-close {
+  position: absolute;
+  right: 1rem;
+  top: 0.75rem;
+  background: none;
+  border: none;
+  font-size: 1.75rem;
+  line-height: 1;
+  color: #888;
+  cursor: pointer;
+}
+#review-delete-close:hover { color: #333; }
+
+#review-delete-title {
+  text-align: center;
+  font-weight: bold;
+  margin-bottom: 1.25rem;
+}
+
+.review-delete-count {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.review-delete-list {
+  overflow: auto;
+  list-style: disc;
+  padding-left: 2rem;
+  margin-bottom: 1.5rem;
+}
+.review-delete-list li { padding: 0.15rem 0; }
+
+/* Two equal-width buttons, mirroring 1.5: Cancel (orange) / Confirm (navy). */
+.review-delete-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: auto;
+}
+.review-delete-btn-cancel,
+.review-delete-btn-confirm {
+  flex: 1 1 0;
+  font-weight: bold;
+  padding: 1.1rem;
+  height: auto;
+  color: #fff;
+  border: none;
+}
+.review-delete-btn-cancel { background: #d0492b; }
+.review-delete-btn-cancel:hover { background: #b93d22; color: #fff; }
+.review-delete-btn-confirm { background: #1b4a72; }
+.review-delete-btn-confirm:hover { background: #163c5d; color: #fff; }
+</style>

--- a/submit_ce/ui/templates/submit/review_files.html
+++ b/submit_ce/ui/templates/submit/review_files.html
@@ -11,6 +11,7 @@
  <script src="{{ url_for('static', filename='js/review_top_level_select.js') }}" defer></script>
  <script src="{{ url_for('static', filename='js/review_delete_cascade.js') }}" defer></script>
  <script src="{{ url_for('static', filename='js/review_used_recompute.js') }}" defer></script>
+ <script src="{{ url_for('static', filename='js/review_delete_confirm.js') }}" defer></script>
  <style>
    /* Oversized-image row highlight (SUBMISSION-172), mirroring 1.5's
       cream row tint. !important so it wins over the is-striped zebra shading. */
@@ -352,6 +353,9 @@
   </div>
   </div>{# /.action-container #}
 </form>
+{# Confirm-on-delete dialog (SUBMISSION-253). Progressive enhancement wired by
+   review_delete_confirm.js; only meaningful when the file form is present. #}
+{% include "submit/review_delete_confirm_modal.html" %}
 {% else %}
   <div class="notification is-warning" role="alert">
     <h2 class="is-size-5 is-marginless">


### PR DESCRIPTION
## Summary

Adds a confirmation dialog to the Review Files page before it deletes files on Continue, for parity with Submit 1.5. Previously the page deleted every checked file (including the ones auto-checked as unused) with no confirmation — unlike the Upload page, which confirms every delete.

## Behavior

- On Continue, if any deletable files are checked, a modal lists them and asks the submitter to confirm before proceeding. Confirm submits; Cancel / Escape / × / backdrop-click dismiss and stay on the page.
- Continuing with nothing checked proceeds straight through — no dialog.
- Go Back and other actions are never intercepted.
- Progressive enhancement: with JavaScript off, the modal never renders and Continue behaves exactly as before, so the no-JS path is unchanged. Confirm submits via `requestSubmit(button)` so the `action=next` value is preserved.

## Design

Mirrors the 1.5 confirm-on-delete dialog: centered title-case heading with a close (×), a centered "By continuing the following N files will be deleted:" lead, a plain bulleted list, and two equal-width Cancel / Confirm buttons.

One intentional deviation from 1.5: the file list scrolls within its own region rather than scrolling the whole dialog, so a large submission (hundreds of files) keeps the heading and buttons in view.

## Tests

- `submit_ce/ui/static/js/tests/review_delete_confirm.test.js` — self-contained Node test (DOM stub, no test runner) covering intercept + list/count, Confirm submitting with the button as submitter, Cancel, Escape, and the no-checked-files pass-through. Run with `node submit_ce/ui/static/js/tests/review_delete_confirm.test.js`.

<img width="1386" height="1247" alt="ReviewFiles-2 0-DeleteModal-Screenshot 2026-08-28 at 11 26 00 AM" src="https://github.com/user-attachments/assets/39be16fe-1b22-468c-9294-7f50d85cc35e" />
